### PR TITLE
Removed assumption about hostnames starting with letters 

### DIFF
--- a/lib/zipkin-tracer/hostname_resolver.rb
+++ b/lib/zipkin-tracer/hostname_resolver.rb
@@ -8,9 +8,7 @@ module ZipkinTracer
 
       each_annotation(spans) do |annotation|
         hostname = annotation.host.ipv4
-        if hostname.to_s =~ /\A[a-zA-Z]/ # hostnames start with letters, else we already have an IP
-          annotation.host.ipv4 = host_to_ip[hostname]
-        end
+        annotation.host.ipv4 = host_to_ip[hostname]
       end
     end
 


### PR DESCRIPTION
Docker containers have hostnames that start with numbers.  It's based on the container hash which you can't control.  The "ipv4" address was being sent as (for example) 465cc3595a43 which caused Zipkin to fail when indexing.  This fix removes the regex check that assumes the hostnames must start with letters.
