### PR TITLE
Standardize key of binary annotation representing http URL

### DIFF
--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -83,7 +83,7 @@ module Trace
   # This class is defined in finagle-thrift. We are adding extra methods here
   class BinaryAnnotation
     SERVER_ADDRESS = 'sa'.freeze
-    URI = 'http.uri'.freeze
+    URI = 'http.url'.freeze
     STATUS = 'http.status'.freeze
     LOCAL_COMPONENT = 'lc'.freeze
 

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -59,7 +59,7 @@ describe ZipkinTracer::FaradayHandler do
       expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
 
       expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('http.uri')
+        expect(key).to eq('http.url')
         expect(value).to eq(url_path)
         expect_host(host, '127.0.0.1', service_name)
       end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -40,7 +40,7 @@ describe ZipkinTracer::RackHandler do
     it 'traces the request' do
       expect(::Trace).to receive(:push).and_call_original.ordered
       expect(tracer).to receive(:with_new_span).ordered.with(anything, 'get').and_call_original
-      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.uri', '/')
+      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.url', '/')
       expect_any_instance_of(Trace::Span).to receive(:record).with(Trace::Annotation::SERVER_RECV)
       expect_any_instance_of(Trace::Span).to receive(:record).with(Trace::Annotation::SERVER_SEND)
       expect(::Trace).to receive(:pop).and_call_original.ordered
@@ -194,7 +194,7 @@ describe ZipkinTracer::RackHandler do
       subject { middleware(app, whitelist_plugin: lambda { |env| true }, sample_rate: 0) }
 
       it 'samples the request' do
-        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.uri', '/')
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.url', '/')
         expect_any_instance_of(Trace::Span).to receive(:record).with(Trace::Annotation::SERVER_RECV)
         expect_any_instance_of(Trace::Span).to receive(:record).with('whitelisted')
         expect_any_instance_of(Trace::Span).to receive(:record).with(Trace::Annotation::SERVER_SEND)

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -94,12 +94,12 @@ describe Trace do
   end
 
   describe Trace::BinaryAnnotation do
-    let(:annotation) { Trace::BinaryAnnotation.new('http.uri', '/', 'STRING', dummy_endpoint) }
+    let(:annotation) { Trace::BinaryAnnotation.new('http.url', '/', 'STRING', dummy_endpoint) }
 
     describe '#to_h' do
       it 'returns a hash representation of a binary annotation' do
         expect(annotation.to_h).to eq(
-          key: 'http.uri',
+          key: 'http.url',
           value: '/',
           endpoint: dummy_endpoint.to_h
         )


### PR DESCRIPTION
Make key of http URL binary annotation standardized.
See https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin/TraceKeys.java#L79

@jcarres-mdsol could you please review?
