### PR TITLE
adds support for 1/0 as values of the sampled header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.19.0
+* Propagates the X-B3-Sampled in the same form it receives it (boolean or an a number)
+* Adds a configuration option to allow a service to emit boolean or numbers for the X-B3-Sampled header
+
 # 0.18.4
 * Uses http.path to annotate paths instead of http.uri.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:annotate_plugin` - plugin function which receives the Rack env, the response status, headers, and body to record annotations
 * `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
-
+* `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
 
 ### Sending traces on outgoing requests with Faraday
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -35,6 +35,10 @@ module ZipkinTracer
       @log_tracing       = config[:log_tracing]
       # When set to false, it uses 1/0 in the 'X-B3-Sampled' header, else uses true/false
       @sampled_as_boolean = config[:sampled_as_boolean] || DEFAULTS[:sampled_as_boolean]
+      # The current default is true for compatibility but services are encouraged to move on.
+      if @sampled_as_boolean
+        @logger && @logger.warn("Using a boolean in the Sampled header is deprecated. Consider setting sampled_as_boolean to false")
+      end
     end
 
     def adapter

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -6,20 +6,35 @@ module ZipkinTracer
   class Config
     attr_reader :service_name, :service_port, :json_api_host,
       :zookeeper, :sample_rate, :logger, :log_tracing,
-      :annotate_plugin, :filter_plugin, :whitelist_plugin
+      :annotate_plugin, :filter_plugin, :whitelist_plugin,
+      :sampled_as_boolean
 
     def initialize(app, config_hash)
       config = config_hash || Application.config(app)
+      # The name of the current service
       @service_name      = config[:service_name]
+      # The port where the current service is running
       @service_port      = config[:service_port]      || DEFAULTS[:service_port]
+      # The address of the Zipkin server which we will send traces to
       @json_api_host     = config[:json_api_host]
+      # Zookeeper information
       @zookeeper         = config[:zookeeper]
+      # Percentage of traces which by default this service traces (as float, 1.0 means 100%)
       @sample_rate       = config[:sample_rate]       || DEFAULTS[:sample_rate]
+      # A block of code which can be called to do extra annotations of traces
       @annotate_plugin   = config[:annotate_plugin]   # call for trace annotation
       @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
       @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
+      # A block of code which can be called to skip traces. Skip tracing if returns false
+      @filter_plugin     = config[:filter_plugin]
+      # A block of code which can be called to force sampling. Forces sampling if returns true
+      @whitelist_plugin  = config[:whitelist_plugin]
       @logger            = Application.logger
       @log_tracing       = config[:log_tracing]       # Was the logger in fact setup by the client?
+      # Was the logger in fact setup by the client?
+      @log_tracing       = config[:log_tracing]
+      # When set to false, it uses 1/0 in the 'X-B3-Sampled' header, else uses true/false
+      @sampled_as_boolean = config[:sampled_as_boolean] || DEFAULTS[:sampled_as_boolean]
     end
 
     def adapter
@@ -38,7 +53,8 @@ module ZipkinTracer
 
     DEFAULTS = {
       sample_rate: 0.1,
-      service_port: 80
+      service_port: 80,
+      sampled_as_boolean: true
     }
 
     def present?(str)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.18.4'.freeze
+  VERSION = '0.19.0'.freeze
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -57,7 +57,7 @@ describe 'integrations' do
     expect(traces[0]['trace_id']).not_to be_empty
     expect(traces[0]['parent_span_id']).to be_empty
     expect(traces[0]['span_id']).not_to be_empty
-    expect([true, false].include?(traces[0]['sampled'])).to be_truthy
+    expect(['true', 'false'].include?(traces[0]['sampled'])).to be_truthy
   end
 
   # Assert that the second level of trace data is correct (or not!).
@@ -68,6 +68,6 @@ describe 'integrations' do
     expect(traces[1]['parent_span_id']).to eq(traces[0]['span_id'])
     expect(traces[1]['span_id']).not_to be_empty
     expect([traces[1]['trace_id'], traces[1]['parent_span_id']].include?(traces[1]['span_id'])).to be_falsey
-    expect([true, false].include?(traces[1]['sampled'])).to be_truthy
+    expect(['true', 'false'].include?(traces[1]['sampled'])).to be_truthy
   end
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 module ZipkinTracer
   RSpec.describe Config do
+    before do
+      allow(Application).to receive(:logger).and_return(Logger.new(nil))
+    end
     [:service_name, :service_port, :json_api_host,
       :zookeeper, :sample_rate, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin].each do |method|
@@ -14,23 +17,15 @@ module ZipkinTracer
 
     it 'sets defaults' do
       config = Config.new(nil, {})
-      [:sample_rate, :service_port].each do |key|
+      [:sample_rate, :service_port, :sampled_as_boolean].each do |key|
         expect(config.send(key)).to_not eq(nil)
       end
     end
 
     describe 'logger' do
-      it 'uses Rails logger if available' do
-        logger = 'TrusmisLogger'
-        object_double("Rails", logger: logger).as_stubbed_const
-
+      it 'uses the application logger' do
         config = Config.new(nil, {})
-        expect(config.logger).to eq(logger)
-      end
-
-      it 'uses STDOUT if nothing was provided and not using rails' do
-        config = Config.new(nil, {})
-        expect(config.logger).to be_kind_of(Logger)
+        expect(config.logger).to eq(Application.logger)
       end
     end
 

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -32,6 +32,7 @@ describe ZipkinTracer::RackHandler do
   let(:host_ip) { 0x11223344 }
   before do
     allow(::Trace::Endpoint).to receive(:host_to_i32).and_return(host_ip)
+    allow(ZipkinTracer::Application).to receive(:logger).and_return(Logger.new(nil))
   end
 
   let(:tracer) {subject.instance_variable_get(:@tracer)}

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -3,6 +3,55 @@ require 'spec_helper'
 describe Trace do
   let(:dummy_endpoint) { Trace::Endpoint.new('127.0.0.1', 9411, 'DummyService') }
 
+  describe Trace::TraceId do
+    let(:traceid) { '234555b04cf7e099' }
+    let(:span_id) { 'c3a555b04cf7e099' }
+    let(:parent_id) { 'f0e71086411b1445' }
+    let(:sampled) { true }
+    let(:flags) { Trace::Flags::EMPTY }
+    let(:trace_id) { Trace::TraceId.new(traceid, parent_id, span_id, sampled, flags) }
+
+    it 'is not a debug trace' do
+      expect(trace_id.debug?).to eq(false)
+    end
+
+    context 'sampled value is 0' do
+      let(:sampled) { '0' }
+      it 'is not sampled' do
+        expect(trace_id.sampled?).to eq(false)
+      end
+    end
+    context 'sampled value is false' do
+      let(:sampled) { 'false' }
+      it 'is sampled' do
+        expect(trace_id.sampled?).to eq(false)
+      end
+    end
+    context 'sampled value is 1' do
+      let(:sampled) { '1' }
+      it 'is sampled' do
+        expect(trace_id.sampled?).to eq(true)
+      end
+    end
+    context 'sampled value is true' do
+      let(:sampled) { 'true' }
+      it 'is sampled' do
+        expect(trace_id.sampled?).to eq(true)
+      end
+    end
+
+    context 'using the debug flag' do
+      let(:flags) { Trace::Flags::DEBUG }
+      it 'is a debug trace' do
+        expect(trace_id.debug?).to eq(true)
+      end
+      it 'get sampled' do
+        expect(trace_id.sampled?).to eq(true)
+      end
+    end
+
+  end
+
   describe Trace::Span do
     let(:span_id) { 'c3a555b04cf7e099' }
     let(:parent_id) { 'f0e71086411b1445' }

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -20,6 +20,9 @@ describe ZipkinTracer::TracerFactory do
   let(:subject) { described_class.new(config) }
   let(:tracer) { double('Trace::NullTracer') }
 
+  before do
+    allow(ZipkinTracer::Application).to receive(:logger).and_return(logger)
+  end
 
   describe 'initializer' do
     # see spec/lib/zipkin_kafka_tracer_spec.rb

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -31,7 +31,7 @@ class TestApp
       'trace_id'        => ::Trace.id.trace_id.to_s,
       'parent_span_id'  => ::Trace.id.parent_id.to_s,
       'span_id'         => ::Trace.id.span_id.to_s,
-      'sampled'         => ::Trace.id.sampled
+      'sampled'         => ::Trace.id.sampled.to_s
     }
     self.class.add_trace(current_trace_info.to_json)
   end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_path              = 'lib'
 
   s.add_dependency 'faraday', '~> 0.8'
-  s.add_dependency 'finagle-thrift', '~> 1.4.1'
+  s.add_dependency 'finagle-thrift', '~> 1.4.2'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 


### PR DESCRIPTION

Reimplementing #69 

After this PR zipkin-tracer will:
- Accept either true/false or 1/0
- Propagate whatever sampled value it gets
- If it is the first service in the trace (no value for sampled) it will user true/false or 1/0 depending on a configuration option

@adriancole  @singram

This PR still needs changing of Changelog, document the new configuration, etc but opening early for comments.
