### PR TITLE
Name the local span by its name

### DIFF
--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -17,7 +17,7 @@ module ZipkinTracer
       result = nil
       if @trace_id.sampled?
         Trace.with_trace_id(@trace_id) do
-          Trace.tracer.with_new_span(@trace_id, Trace::BinaryAnnotation::LOCAL_COMPONENT) do |span|
+          Trace.tracer.with_new_span(@trace_id, local_component_value) do |span|
             result = block.call(span)
             span.record_local_component local_component_value
           end

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -15,8 +15,8 @@ describe ZipkinTracer::TraceClient do
   describe '.local_component_span' do
     context 'called with block' do
       it 'creates new span' do
-        expect(Trace.tracer).to receive(:with_new_span).ordered.with(anything, 'lc').and_call_original
-        expect_any_instance_of(Trace::Span).to receive(:record_local_component).with('lc_value')
+        expect(Trace.tracer).to receive(:with_new_span).ordered.with(anything, 'lc_value').and_call_original
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('lc', 'lc_value')
 
         subject.local_component_span(lc_value) do |ztc|
           ztc.record('value')


### PR DESCRIPTION
This PR allows us to use the name passed to `trace_local_component` instead of the `lc` constant that serves for the binary annotation.

Right now all the local traces created are named `lc`.
This makes it harder to debug local traces.
We have the `lc` binary annotation to categorize this.
According to https://github.com/openzipkin/zipkin/issues/808 this is enough for a local span.

## before

![image](https://cloud.githubusercontent.com/assets/483012/20055516/bba932ea-a4e1-11e6-9a6a-44f8f9a21f06.png)

## after

![image](https://cloud.githubusercontent.com/assets/483012/20055503/ade34be6-a4e1-11e6-8bb1-bb8dde94d454.png)
