### PR TITLE
Add a noop flush! in null tracer

### DIFF
--- a/lib/zipkin-tracer/zipkin_null_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_null_tracer.rb
@@ -7,5 +7,9 @@ module Trace
       span = Span.new(name, trace_id)
       yield span
     end
+
+    def flush!
+      # NOOP
+    end
   end
 end


### PR DESCRIPTION
I am instrumenting background jobs and with sidekiq, I have to flush the queue myself at the end of a job.

This will ensure that all the tracers have the `flush!` method implemented.
So that whenever it is traced or not, the tracer reacts similarly.