### PR TITLE
Add basic sidekiq middleware

### DIFF
--- a/lib/zipkin-tracer/sidekiq/middleware.rb
+++ b/lib/zipkin-tracer/sidekiq/middleware.rb
@@ -1,0 +1,36 @@
+module ZipkinTracer
+  module Sidekiq
+    class Middleware
+      def initialize(app, config = nil)
+        @app = app
+        @config = Config.new(app, config).freeze
+        @tracer = TracerFactory.new.tracer(@config)
+      end
+
+      def sample?
+        rand < @config.sample_rate
+      end
+
+      def call(worker, item, _queue)
+        id = Trace.generate_id
+        trace_id = Trace::TraceId.new(id, nil, id, sample?, ::Trace::Flags::EMPTY)
+
+        result = nil
+        klass = item["wrapped".freeze] || worker.class.to_s
+        ::Trace.with_trace_id(trace_id) do
+          if sample?
+            @tracer.with_new_span(trace_id, klass) do |span|
+              span.record("mr")
+              result = yield
+              span.record("ms")
+            end
+          else
+            result = yield
+          end
+        end
+        ::Trace.tracer.flush! if ::Trace.tracer.respond_to?(:flush!)
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a way to trace background jobs in Sidekiq.

This lacks documentation and tests but is opened early to have a feel of the need of the community for this.

This is used this way.

```
options = {
  service_port:  443,
  service_name:  service_name,
  sample_rate:   ENV.fetch("ZIPKIN_SAMPLE_RATE", 0.1).to_f,
  json_api_host: ENV.fetch("ZIPKIN_API_HOST", "https://zipkin.io")
}

Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    chain.add ZipkinTracer::Sidekiq::Middleware, options
  end
end
```