### PR TITLE
passes the http verb to the recognize_path method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.18.6
+* Passes HTTP Method to recognize_path
+
 # 0.18.5
 * `NullTracer` has a noop `flush!` method.
 * Spans from `local_component_span` will be named according to `local_component_value` over `lc`.

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -3,9 +3,9 @@ module ZipkinTracer
   # Useful methods on the Application we are instrumenting
   class Application
     # If the request is not valid for this service, we do not what to trace it.
-    def self.routable_request?(path_info)
+    def self.routable_request?(path_info, http_method)
       return true unless defined?(Rails) # If not running on a Rails app, we can't verify if it is invalid
-      Rails.application.routes.recognize_path(path_info)
+      Rails.application.routes.recognize_path(path_info, method: http_method)
       true
     rescue ActionController::RoutingError
       false

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -34,7 +34,7 @@ module ZipkinTracer
       zipkin_env = ZipkinEnv.new(env, @config)
       trace_id = zipkin_env.trace_id
       Trace.with_trace_id(trace_id) do
-        if !trace_id.sampled? || !Application.routable_request?(env['PATH_INFO'])
+        if !trace_id.sampled? || !routable_request?(env)
           @app.call(env)
         else
           @tracer.with_new_span(trace_id, zipkin_env.env['REQUEST_METHOD'].to_s.downcase) do |span|
@@ -45,6 +45,10 @@ module ZipkinTracer
     end
 
     private
+
+    def routable_request?(env)
+      Application.routable_request?(env['PATH_INFO'],  env['REQUEST_METHOD'])
+    end
 
     def annotate_plugin(env, status, response_headers, response_body)
       @config.annotate_plugin.call(env, status, response_headers, response_body) if @config.annotate_plugin

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.18.5'.freeze
+  VERSION = '0.18.6'.freeze
 end

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -2,25 +2,61 @@ require 'spec_helper'
 module ZipkinTracer
   RSpec.describe Application do
     describe '.routable_request?' do
-      it 'returns rails routable information if available' do
-        stub_const("Rails", Class.new)
-        allow(Rails).to receive_message_chain("application.routes.recognize_path") { nil }
-        expect(Application.routable_request?("path")).to eq(true)
+      subject { Application.routable_request?("path", "METHOD") }
+
+      context 'Rails available' do
+        before do
+          stub_const('Rails', Class.new)
+        end
+
+        context 'route is found' do
+          before do
+            allow(Rails).to receive_message_chain('application.routes.recognize_path') { nil }
+          end
+
+          it 'is true' do
+            expect(subject).to eq(true)
+          end
+        end
+
+        context 'route is not found' do
+          before do
+            stub_const('ActionController::RoutingError', StandardError)
+            allow(Rails).to receive_message_chain('application.routes.recognize_path').and_raise ActionController::RoutingError
+          end
+
+          it 'is false' do
+            expect(subject).to eq(false)
+          end
+        end
       end
-      it 'returns true when Rails not available' do
-        expect(Application.routable_request?("path")).to eq(true)
+
+      context 'Rails not available' do
+        it 'is true' do
+          expect(subject).to eq(true)
+        end
       end
     end
 
     describe '.logger' do
-      it 'returns rails logger if available' do
-        stub_const("Rails", Class.new)
-        expect(Rails).to receive(:logger)
-        Application.logger
+      subject { Application.logger }
+
+      context 'Rails defined' do
+        before { stub_const("Rails", Class.new) }
+
+        it 'returns rails logger if available' do
+          expect(Rails).to receive(:logger)
+
+          subject
+        end
       end
-      it 'returns standard logger if there is no Rails logger' do
-        expect(Logger).to receive(:new).with(STDOUT)
-        Application.logger
+
+      context 'Rails not defined' do
+        it 'returns standard logger if there is no Rails logger' do
+          expect(Logger).to receive(:new).with(STDOUT)
+
+          subject
+        end
       end
     end
 
@@ -28,6 +64,7 @@ module ZipkinTracer
       it 'returns empty hash if no config' do
         expect(Application.config(nil)).to eq({})
       end
+
       it 'returns config if available' do
         app = double('application')
         config = { config: true }

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -44,7 +44,7 @@ module ZipkinTracer
       context 'Rails defined' do
         before { stub_const("Rails", Class.new) }
 
-        it 'returns rails logger if available' do
+        it 'returns rails logger' do
           expect(Rails).to receive(:logger)
 
           subject
@@ -52,7 +52,7 @@ module ZipkinTracer
       end
 
       context 'Rails not defined' do
-        it 'returns standard logger if there is no Rails logger' do
+        it 'returns standard logger' do
           expect(Logger).to receive(:new).with(STDOUT)
 
           subject

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -67,21 +67,15 @@ describe ZipkinTracer::RackHandler do
 
     context 'accessing a valid URL of our service' do
       before do
-        rails = double('Rails')
-        allow(rails).to receive(:logger)
-        allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_return(controller: 'trusmis', action: 'new')
-        stub_const('Rails', rails)
+        allow(middleware(app)).to receive(:routable_request?).and_return(true)
       end
+
       it_should_behave_like 'traces the request'
     end
 
     context 'accessing an invalid URL our our service' do
       before do
-        rails = double('Rails')
-        allow(rails).to receive(:logger)
-        stub_const('ActionController::RoutingError', StandardError)
-        allow(rails).to receive_message_chain(:application, :routes, :recognize_path).and_raise(ActionController::RoutingError)
-        stub_const('Rails', rails)
+        allow(middleware(app)).to receive(:routable_request?).and_return(false)
       end
 
       it 'calls the app' do


### PR DESCRIPTION
Currently the http verb is not passed to the recognize_path method. This means that all paths are interpreted as GET (see [here](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/route_set.rb#L728)).

We are currently getting false negatives due to this problem.

This PR fixes by passing in the http verb.

Due to the method (recognize_path) being part of Rails (not this gem) we had to continue to only stub the method, so I could not make a true "failing test."