### PR TITLE
limits the required zipkin headers to x_b3_trace_id and x_b3_span_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.19.1
+* Limits the required headers to x_b3_trace_id and x_b3_span_id as per spec.
+
 # 0.19.0
 * Propagates the X-B3-Sampled in the same form it receives it (boolean or 1/0)
 * Adds a configuration option to allow a service to emit boolean or numbers for the X-B3-Sampled header

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -1,0 +1,72 @@
+module ZipkinTracer
+  # This class manages the Zipkin related information in the Rack environment.
+  # It is only used by the rack middleware.
+  class ZipkinEnv
+    attr_reader :env
+
+    def initialize(env, config)
+      @env    = env
+      @config = config
+    end
+
+    def trace_id(default_flags = Trace::Flags::EMPTY)
+      trace_id, span_id, parent_span_id = retrieve_or_generate_ids
+      sampled = sampled_header_value(@env['HTTP_X_B3_SAMPLED'])
+      flags = (@env['HTTP_X_B3_FLAGS'] || default_flags).to_i
+      Trace::TraceId.new(trace_id, parent_span_id, span_id, sampled, flags)
+    end
+
+    def called_with_zipkin_headers?
+      @called_with_zipkin_headers ||= B3_REQUIRED_HEADERS.all? { |key| @env.key?(key) }
+    end
+
+    def force_sample?
+      @force_sample ||= @config.whitelist_plugin && @config.whitelist_plugin.call(@env)
+    end
+
+    private
+
+    B3_REQUIRED_HEADERS = %w(HTTP_X_B3_TRACEID HTTP_X_B3_SPANID).freeze
+    B3_OPT_HEADERS = %w(HTTP_X_B3_PARENTSPANID HTTP_X_B3_SAMPLED HTTP_X_B3_FLAGS).freeze
+
+    def retrieve_or_generate_ids
+      if called_with_zipkin_headers?
+        trace_id, span_id = @env.values_at(*B3_REQUIRED_HEADERS)
+        parent_span_id = @env['HTTP_X_B3_PARENTSPANID']
+      else
+        trace_id = span_id = Trace.generate_id
+        parent_span_id = nil
+      end
+      [trace_id, span_id, parent_span_id]
+    end
+
+    def new_sampled_header_value(sampled)
+      case [@config.sampled_as_boolean, sampled]
+      when [true, true]
+        'true'
+      when [true, false]
+        'false'
+      when [false, true]
+        '1'
+      when [false, false]
+        '0'
+      end
+    end
+
+    def current_trace_sampled?
+      rand < @config.sample_rate
+    end
+
+    def sampled_header_value(parent_trace_sampled)
+      if parent_trace_sampled  # A service upstream decided this goes in all the way
+        parent_trace_sampled
+      else
+        new_sampled_header_value(force_sample? || current_trace_sampled? && !filtered?)
+      end
+    end
+
+    def filtered?
+      @config.filter_plugin && !@config.filter_plugin.call(@env)
+    end
+  end
+end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module ZipkinTracer
-  VERSION = '0.19.0'.freeze
+  VERSION = '0.19.1'.freeze
 end

--- a/spec/lib/rack/zipkin_env_spec.rb
+++ b/spec/lib/rack/zipkin_env_spec.rb
@@ -1,0 +1,151 @@
+require 'rack/mock'
+require 'spec_helper'
+
+describe ZipkinTracer::ZipkinEnv do
+  def mock_env(params = {}, path = '/')
+    Rack::MockRequest.env_for(path, params)
+  end
+
+  let(:path) { '/to_the_lighthouse' }
+  let(:sampled_as_boolean) { true }
+  let(:config) do
+    instance_double(
+      ZipkinTracer::Config,
+      filter_plugin: proc { false },
+      whitelist_plugin: proc { true },
+      sample_rate: 1,
+      sampled_as_boolean: sampled_as_boolean
+    )
+  end
+  let(:env) { mock_env }
+  let(:zipkin_env) { described_class.new(env, config) }
+
+  it 'allows access to the original environment' do
+    expect(zipkin_env.env).to eq(env)
+  end
+
+  context 'whitelist_plugin returns false' do
+    let(:config) do
+      instance_double(
+        ZipkinTracer::Config,
+        filter_plugin: proc { false },
+        whitelist_plugin: proc { false },
+        sample_rate: 1,
+        sampled_as_boolean: sampled_as_boolean
+      )
+    end
+
+    it 'sampling is not forced' do
+      expect(zipkin_env.force_sample?).to eq(false)
+    end
+  end
+
+  context 'whitelist_plugin returns true' do
+    let(:config) do
+      instance_double(
+        ZipkinTracer::Config,
+        filter_plugin: proc { false },
+        whitelist_plugin: proc { true },
+        sample_rate: 1,
+        sampled_as_boolean: sampled_as_boolean
+      )
+    end
+
+    it 'sampling is forced' do
+      expect(zipkin_env.force_sample?).to eq(true)
+    end
+  end
+
+  context 'without zipkin headers' do
+    let(:env) { mock_env }
+
+    it '#called_with_zipkin_headers? returns false' do
+      expect(zipkin_env.called_with_zipkin_headers?).to eq(false)
+    end
+
+    it 'generates a trace_id and a span_id' do
+      trace_id = zipkin_env.trace_id
+      expect(trace_id.trace_id).not_to eq(nil)
+      expect(trace_id.span_id).not_to eq(nil)
+      expect(trace_id.span_id.to_i).to eq(trace_id.trace_id.to_i)
+    end
+
+    it 'parent_id is nil' do
+      expect(zipkin_env.trace_id.parent_id).to eq(nil)
+    end
+
+    it 'flags default to empty' do
+      expect(zipkin_env.trace_id.flags).to eq(Trace::Flags::EMPTY)
+    end
+
+    it 'sampling information is set' do
+      # In this spec we are forcing sampling with the whitelist_plugin
+      expect(zipkin_env.trace_id.sampled?).to eq(true)
+    end
+  end
+
+  context 'with zipkin headers' do
+    let(:id) { rand(1000) }
+    let(:zipkin_headers) { { 'HTTP_X_B3_TRACEID' => id, 'HTTP_X_B3_SPANID' => id } }
+    let(:env) { mock_env(zipkin_headers) }
+
+    it '#called_with_zipkin_headers? returns true' do
+      expect(zipkin_env.called_with_zipkin_headers?).to eq(true)
+    end
+
+    context 'parent_id is not provided' do
+      it 'uses the trace_id and span_id' do
+        trace_id = zipkin_env.trace_id
+        expect(trace_id.trace_id.to_i).to eq(id)
+        expect(trace_id.span_id.to_i).to eq(id)
+      end
+
+      it 'parent_id is empty' do
+        expect(zipkin_env.trace_id.parent_id).to eq(nil)
+      end
+    end
+
+    context 'parent_id is provided' do
+      let(:parent_id) { rand(131) }
+      let(:zipkin_headers) do
+        { 'HTTP_X_B3_TRACEID' => id, 'HTTP_X_B3_SPANID' => id, 'HTTP_X_B3_PARENTSPANID' => parent_id }
+      end
+
+      it 'uses the trace_id and span_id' do
+        trace_id = zipkin_env.trace_id
+        expect(trace_id.trace_id.to_i).to eq(id)
+        expect(trace_id.span_id.to_i).to eq(id)
+      end
+
+      it 'uses the parent_id' do
+        expect(zipkin_env.trace_id.parent_id.to_i).to eq(parent_id)
+      end
+    end
+
+    context 'all information is provided' do
+      let(:parent_id) { rand(131) }
+      let(:zipkin_headers) do
+        { 'HTTP_X_B3_TRACEID' => id, 'HTTP_X_B3_SPANID' => id, 'HTTP_X_B3_PARENTSPANID' => parent_id,
+          'HTTP_X_B3_SAMPLED' => 'true', 'HTTP_X_B3_FLAGS' => 0 }
+      end
+
+      it 'uses the trace_id and span_id' do
+        trace_id = zipkin_env.trace_id
+        expect(trace_id.trace_id.to_i).to eq(id)
+        expect(trace_id.span_id.to_i).to eq(id)
+      end
+
+      it 'uses the parent_id' do
+        expect(zipkin_env.trace_id.parent_id.to_i).to eq(parent_id)
+      end
+
+      it 'uses the sampling information' do
+        expect(zipkin_env.trace_id.sampled?).to eq(true)
+      end
+
+      it 'uses the flags' do
+        expect(zipkin_env.trace_id.flags.to_i).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION

Changes tracer to behave as per zipkin spec, the required headers are only the ones for trace_id and span_id.
Should solve #87 

I've just discovered that having a class under private in Ruby does not make it private, you need to use `private_constant` instead which I haven't seen in my life and I guess other developers will be surprised to see it. So I've moved the previously_thought_to_be_private class into its own file and made the modifications there.

@ykitamura-mdsol  @jfeltesse-mdsol  @ssteeg-mdsol  @adriancole  @rgueldem
