### PR TITLE
Add bin. annotation http.path for every request

### DIFF
--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -53,7 +53,7 @@ module ZipkinTracer
 
     def trace!(span, zipkin_env, &block)
       # if called by a service, the caller already added the information
-      trace_request_information(span, zipkin_env.env) unless zipkin_env.called_with_zipkin_headers?
+      trace_request_information(span, zipkin_env.env)
       span.record(Trace::Annotation::SERVER_RECV)
       span.record('whitelisted') if zipkin_env.force_sample?
       status, headers, body = yield


### PR DESCRIPTION
Even though incoming request comes from a traced service it is not guaranteed that `http.path|url|uri` was added at a client side.

@jcarres-mdsol could you please review? 