### PR TITLE
fixes faraday middleware and add new convenient classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.0
+* Bugfix: The Faraday middleware does not leave in the container any generated Id
+* Added TraceContainer and TraceGenerator to provide easier abstractions to interact with this library
+
 # 0.19.1
 * Limits the required headers to x_b3_trace_id and x_b3_span_id as per spec.
 
@@ -11,7 +15,6 @@
 # 0.18.5
 * `NullTracer` has a noop `flush!` method.
 * Spans from `local_component_span` will be named according to `local_component_value` over `lc`.
->>>>>>> master
 
 # 0.18.4
 * Uses http.path to annotate paths instead of http.uri.

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -2,6 +2,8 @@ require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
 require 'zipkin-tracer/trace_client'
+require 'zipkin-tracer/trace_container'
+require 'zipkin-tracer/trace_generator'
 
 begin
   require 'faraday'

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -39,6 +39,7 @@ module ZipkinTracer
       if @sampled_as_boolean
         @logger && @logger.warn("Using a boolean in the Sampled header is deprecated. Consider setting sampled_as_boolean to false")
       end
+      Trace.sample_rate = @sample_rate
     end
 
     def adapter

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -12,8 +12,8 @@ module ZipkinTracer
     end
 
     def call(env)
-      trace_id = Trace.id.next_id
-      Trace.with_trace_id(trace_id) do
+      trace_id = TraceGenerator.new.next_trace_id
+      TraceContainer.with_trace_id(trace_id) do
         b3_headers.each do |method, header|
           env[:request_headers][header] = trace_id.send(method).to_s
         end

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -17,7 +17,7 @@ module ZipkinTracer
     def call(env)
       zipkin_env = ZipkinEnv.new(env, @config)
       trace_id = zipkin_env.trace_id
-      Trace.with_trace_id(trace_id) do
+      TraceContainer.with_trace_id(trace_id) do
         if !trace_id.sampled? || !routable_request?(env)
           @app.call(env)
         else

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -1,6 +1,7 @@
 require 'finagle-thrift/trace'
 require 'zipkin-tracer/zipkin_tracer_base'
-
+# Module with a mix of functions and overwrites from the finagle implementation:
+# https://github.com/twitter/finagle/blob/finagle-6.39.0/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
 module Trace
 
   # We need this to access the tracer from the Faraday middleware.
@@ -8,11 +9,8 @@ module Trace
     @tracer
   end
 
-  def self.with_trace_id(trace_id, &block)
-    self.push(trace_id)
-    yield
-  ensure
-    self.pop
+  def sample_rate
+    @sample_rate
   end
 
   # A TraceId contains all the information of a given trace id

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -4,19 +4,19 @@ module ZipkinTracer
     end
   end
 
+  # The trace client provides the user of this library an API to interact
+  # with tracing information.
   class TraceClient
     def self.local_component_span(local_component_value, &block)
-      client = self.new
-      client.trace(local_component_value, &block)
+      new.trace(local_component_value, &block)
     end
 
     def trace(local_component_value, &block)
       raise ArgumentError, "no block given" unless block
-
-      @trace_id = Trace.id.next_id
+      @trace_id = TraceGenerator.new.next_trace_id
       result = nil
       if @trace_id.sampled?
-        Trace.with_trace_id(@trace_id) do
+        TraceContainer.with_trace_id(@trace_id) do
           Trace.tracer.with_new_span(@trace_id, local_component_value) do |span|
             result = block.call(span)
             span.record_local_component local_component_value

--- a/lib/zipkin-tracer/trace_container.rb
+++ b/lib/zipkin-tracer/trace_container.rb
@@ -1,0 +1,34 @@
+module ZipkinTracer
+  # This class manages a thread-unique container with the stack of traceIds
+  # This stack may grow if for instance the current process creates local components inside local components
+  class TraceContainer
+    class << self
+      def with_trace_id(trace_id, &_block)
+        container.push(trace_id)
+        yield
+      ensure
+        container.pop
+      end
+
+      def current
+        container.last
+      end
+
+      def tracing_information_set?
+        !container.empty?
+      end
+
+      # DO NOT USE unless you ABSOLUTELY know what you are doing.
+      def cleanup!
+        Thread.current[TRACE_STACK] = []
+      end
+
+      private
+
+      def container
+        Thread.current[TRACE_STACK] ||= []
+      end
+      TRACE_STACK = :trace_stack
+    end
+  end
+end

--- a/lib/zipkin-tracer/trace_generator.rb
+++ b/lib/zipkin-tracer/trace_generator.rb
@@ -1,0 +1,31 @@
+module ZipkinTracer
+  # This class generates trace ids.
+  class TraceGenerator
+    # Next id, based on the current information in the container
+    def next_trace_id
+      if TraceContainer.tracing_information_set?
+        TraceContainer.current.next_id
+      else
+        generate_trace_id
+      end
+    end
+
+    def generate_trace_id
+      span_id = generate_id
+      Trace::TraceId.new(span_id, nil, span_id, should_sample?.to_s, Trace::Flags::EMPTY)
+    end
+
+    def should_sample?
+      rand < (Trace.sample_rate || DEFAULT_SAMPLE_RATE)
+    end
+
+    private
+
+    def generate_id
+      rand(TRACE_ID_UPPER_BOUND)
+    end
+
+    TRACE_ID_UPPER_BOUND = 2**64
+    DEFAULT_SAMPLE_RATE = 0.001
+  end
+end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.19.1'.freeze
+  VERSION = '0.20.0'.freeze
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -6,12 +6,16 @@ module ZipkinTracer
       allow(Application).to receive(:logger).and_return(Logger.new(nil))
     end
     [:service_name, :service_port, :json_api_host,
-      :zookeeper, :sample_rate, :log_tracing,
+      :zookeeper, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
         config = Config.new(nil, { method => value })
         expect(config.send(method)).to eq(value)
+      end
+      it 'can set a sample rate between 0 and 1' do
+        config = Config.new(nil, sample_rate: 0.3)
+        expect(config.sample_rate).to eq(0.3)
       end
     end
 

--- a/spec/lib/trace_generator_spec.rb
+++ b/spec/lib/trace_generator_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe ZipkinTracer::TraceGenerator do
+  let(:subject) { described_class.new }
+
+  describe '#generate_id' do
+    it 'returns a traceID' do
+      expect(subject.generate_trace_id.class).to eq(Trace::TraceId)
+    end
+
+    it 'is a sampled trace if sampling' do
+      allow(Trace).to receive(:sample_rate).and_return(1)
+      trace_id = subject.generate_trace_id
+      expect(trace_id.sampled?).to eq(true)
+    end
+
+    it 'is not sampled trace if not sampling' do
+      allow(Trace).to receive(:sample_rate).and_return(0)
+      trace_id = subject.generate_trace_id
+      expect(trace_id.sampled?).to eq(false)
+    end
+  end
+
+  describe '#next_trace_id' do
+    context 'trace container has traces' do
+      let(:trace_id) { rand(1000) }
+      let(:span_id) { rand(1011) }
+
+      it 'returns the trace in the container' do
+        ZipkinTracer::TraceContainer.with_trace_id(Trace::TraceId.new(trace_id, nil, span_id, true.to_s, Trace::Flags::EMPTY)) do
+          new_trace_id = subject.next_trace_id
+          expect(new_trace_id.trace_id.to_i).to eq(trace_id)
+          expect(new_trace_id.parent_id.to_i).to eq(span_id.to_i)
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The faraday middleware created ids and cleaned up after him which is good,  except when there were no ids to begin with.
This fixes the issue and allows to always clean up after him.
Also added more classes because I like classes

@ykitamura-mdsol  @adriancole  @jfeltesse-mdsol  @ssteeg-mdsol 