### PR TITLE
Add an Excon middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.20.2
+# 0.21.0
 * Added an Excon middleware
 
 # 0.20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.20.2
+* Added an Excon middleware
+
 # 0.20.1
 * Bugfix: Properly handle the `sampled_as_boolean` configuration option
 

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -10,3 +10,9 @@ begin
   require 'zipkin-tracer/faraday/zipkin-tracer'
 rescue LoadError #Faraday is not available, we do not load our code.
 end
+
+begin
+  require 'excon'
+  require 'zipkin-tracer/excon/zipkin-tracer'
+rescue LoadError
+end

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -4,65 +4,70 @@ require 'uri'
 require 'excon'
 
 module ZipkinTracer
-    class ExconHandler < Excon::Middleware::Base
-      def initialize(stack)
-        @stack = stack
-        # Excon does not currently provide a way to parameterize middlewares.
-        @service_name = ENV.fetch('ZIPKIN_SERVICE_NAME', 'unknown-service')
-      end
+  class ExconHandler < Excon::Middleware::Base
+    def initialize(stack)
+      @stack = stack
+      # Excon does not currently provide a way to parameterize middlewares.
+      @service_name = ENV.fetch('ZIPKIN_SERVICE_NAME', 'unknown-service')
+    end
 
-      def error_call(datum)
-        # do stuff
-        puts "error call"
-        @stack.error_call(datum)
-      end
+    def error_call(datum)
+      # do stuff
+      puts "error call"
+      @stack.error_call(datum)
+    end
 
-      def request_call(datum)
-        puts "request call"
-        byebug
-        trace_id = TraceGenerator.new.next_trace_id
-        TraceContainer.with_trace_id(trace_id) do
-          b3_headers.each do |method, header|
-            datum[:headers][header] = trace_id.send(method).to_s
-          end
-          if trace_id.sampled?
-            trace!(datum, trace_id)
-          else
-            @stack.request_call(datum)
-          end
+    def request_call(datum)
+      puts "request call"
+      trace_id = TraceGenerator.new.next_trace_id
+      TraceContainer.with_trace_id(trace_id) do
+        b3_headers.each do |method, header|
+          datum[:headers][header] = trace_id.send(method).to_s
         end
+
+        trace!(datum, trace_id) if trace_id.sampled?
       end
 
-      def response_call(datum)
-        puts "response call"
-        response = datum[:response]
-        local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+      @stack.request_call(datum)
+    end
+
+    def response_call(datum)
+      puts "response call"
+      response = datum[:response]
+      local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+
+      if span = datum[:span]
         span.record_tag(Trace::BinaryAnnotation::STATUS, response[:status].to_s, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
         span.record(Trace::Annotation::CLIENT_RECV, local_endpoint)
-        @stack.response_call(datum)
       end
 
-      SERVER_ADDRESS_SPECIAL_VALUE = '1'.freeze
+      @stack.response_call(datum)
+    end
 
-      def b3_headers
-        {
-          trace_id: 'X-B3-TraceId',
-          parent_id: 'X-B3-ParentSpanId',
-          span_id: 'X-B3-SpanId',
-          sampled: 'X-B3-Sampled',
-          flags: 'X-B3-Flags'
-        }
-      end
+    SERVER_ADDRESS_SPECIAL_VALUE = '1'.freeze
 
-      def trace!(datum, trace_id)
-        url = datum[:url].respond_to?(:host) ? datum[:url] : URI.parse(datum[:url].to_s)
-        local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
-        remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name, local_endpoint.ip_format) # The endpoint we are calling.
-        Trace.tracer.with_new_span(trace_id, datum[:method].to_s.downcase) do |span|
-          # annotate with method (GET/POST/etc.) and uri path
-          span.record_tag(Trace::BinaryAnnotation::PATH, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
-          span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint)
-          span.record(Trace::Annotation::CLIENT_SEND, local_endpoint)
+    def b3_headers
+      {
+        trace_id: 'X-B3-TraceId',
+        parent_id: 'X-B3-ParentSpanId',
+        span_id: 'X-B3-SpanId',
+        sampled: 'X-B3-Sampled',
+        flags: 'X-B3-Flags'
+      }
+    end
+
+    def trace!(datum, trace_id)
+      url = datum[:url].respond_to?(:host) ? datum[:url] : URI.parse(datum[:url].to_s)
+      local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+      remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name, local_endpoint.ip_format) # The endpoint we are calling.
+
+      Trace.tracer.with_new_span(trace_id, datum[:method].to_s.downcase) do |span|
+        # annotate with method (GET/POST/etc.) and uri path
+        span.record_tag(Trace::BinaryAnnotation::PATH, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
+        span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint)
+        span.record(Trace::Annotation::CLIENT_SEND, local_endpoint)
+
+        datum[:span] = span
       end
     end
   end

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -19,8 +19,7 @@ module ZipkinTracer
 
       def request_call(datum)
         puts "request call"
-        require 'pry'
-        binding.pry
+        byebug
         trace_id = TraceGenerator.new.next_trace_id
         TraceContainer.with_trace_id(trace_id) do
           b3_headers.each do |method, header|

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -5,7 +5,7 @@ require 'excon'
 
 module ZipkinTracer
   class ExconHandler < Excon::Middleware::Base
-    def initialize(stack)
+    def initialize(_)
       super
     end
 
@@ -78,6 +78,8 @@ module ZipkinTracer
         # store the span in the datum hash so it can be used in the response_call
         datum[:span] = span
       end
+    rescue ArgumentError, URI::Error => e
+      # Ignore URI errors, don't trace if there is no URI
     end
   end
 end

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -63,7 +63,8 @@ module ZipkinTracer
     end
 
     def trace!(datum, trace_id)
-      url = URI::Generic.build(datum)
+      url_string = Excon::Utils::request_uri(datum)
+      url = URI(url_string)
 
       Trace.tracer.with_new_span(trace_id, datum[:method].to_s.downcase) do |span|
         # annotate with method (GET/POST/etc.) and uri path

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -69,7 +69,7 @@ module ZipkinTracer
       Trace.tracer.with_new_span(trace_id, datum[:method].to_s.downcase) do |span|
         # annotate with method (GET/POST/etc.) and uri path
         span.record_tag(Trace::BinaryAnnotation::PATH, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
-        span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint(url, @service_name))
+        span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint(url, url.host))
         span.record(Trace::Annotation::CLIENT_SEND, local_endpoint)
 
         # store the span in the datum hash so it can be used in the response_call

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -6,8 +6,6 @@ require 'excon'
 module ZipkinTracer
   class ExconHandler < Excon::Middleware::Base
     def initialize(stack)
-      # Excon does not currently provide a way to parameterize middlewares.
-      @service_name = ENV.fetch('ZIPKIN_SERVICE_NAME', 'unknown-service')
       super
     end
 

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -1,0 +1,70 @@
+require 'finagle-thrift/trace'
+require 'finagle-thrift/tracer'
+require 'uri'
+require 'excon'
+
+module ZipkinTracer
+    class ExconHandler < Excon::Middleware::Base
+      def initialize(stack)
+        @stack = stack
+        # Excon does not currently provide a way to parameterize middlewares.
+        @service_name = ENV.fetch('ZIPKIN_SERVICE_NAME', 'unknown-service')
+      end
+
+      def error_call(datum)
+        # do stuff
+        puts "error call"
+        @stack.error_call(datum)
+      end
+
+      def request_call(datum)
+        puts "request call"
+        require 'pry'
+        binding.pry
+        trace_id = TraceGenerator.new.next_trace_id
+        TraceContainer.with_trace_id(trace_id) do
+          b3_headers.each do |method, header|
+            datum[:headers][header] = trace_id.send(method).to_s
+          end
+          if trace_id.sampled?
+            trace!(datum, trace_id)
+          else
+            @stack.request_call(datum)
+          end
+        end
+      end
+
+      def response_call(datum)
+        puts "response call"
+        response = datum[:response]
+        local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+        span.record_tag(Trace::BinaryAnnotation::STATUS, response[:status].to_s, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
+        span.record(Trace::Annotation::CLIENT_RECV, local_endpoint)
+        @stack.response_call(datum)
+      end
+
+      SERVER_ADDRESS_SPECIAL_VALUE = '1'.freeze
+
+      def b3_headers
+        {
+          trace_id: 'X-B3-TraceId',
+          parent_id: 'X-B3-ParentSpanId',
+          span_id: 'X-B3-SpanId',
+          sampled: 'X-B3-Sampled',
+          flags: 'X-B3-Flags'
+        }
+      end
+
+      def trace!(datum, trace_id)
+        url = datum[:url].respond_to?(:host) ? datum[:url] : URI.parse(datum[:url].to_s)
+        local_endpoint = Trace.default_endpoint # The rack middleware set this up for us.
+        remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name, local_endpoint.ip_format) # The endpoint we are calling.
+        Trace.tracer.with_new_span(trace_id, datum[:method].to_s.downcase) do |span|
+          # annotate with method (GET/POST/etc.) and uri path
+          span.record_tag(Trace::BinaryAnnotation::PATH, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
+          span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint)
+          span.record(Trace::Annotation::CLIENT_SEND, local_endpoint)
+      end
+    end
+  end
+end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.20.1'.freeze
+  VERSION = '0.20.2.beta.2'.freeze
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.20.2'.freeze
+  VERSION = '0.21.0'.freeze
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.20.2.beta.2'.freeze
+  VERSION = '0.20.2'.freeze
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -15,10 +15,8 @@ describe ZipkinTracer::ExconHandler do
   before do
     Excon.defaults[:middlewares].unshift(ZipkinTracer::ExconHandler)
     Excon.defaults[:mock] = true
-    Excon.stub({ path: '/' }, body: 'index')
-    Excon.stub({ path: '/hello' }, body: 'world')
-    Excon.stub({ path: '/hello', query: 'message=world' }, body: 'hi!')
-    Excon.stub({ path: '/world' }, body: 'universe')
+
+    Excon.stub({ path: url_path }, body: 'world')
 
     Trace.tracer = Trace::NullTracer.new
     Trace.push(trace_id)
@@ -32,6 +30,6 @@ describe ZipkinTracer::ExconHandler do
     connection = Excon.new(raw_url)
     response = connection.get
 
-    assert_equal 'world', response.body
+    expect(response.body).to eq('world')
   end
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -2,46 +2,204 @@ require 'spec_helper'
 require 'zipkin-tracer/zipkin_null_tracer'
 
 describe ZipkinTracer::ExconHandler do
+  HEX_REGEX = /\A\h{16}\z/
+
   let(:hostname) { 'service.example.com' }
-  let(:host_ip)  { 0x11223344 }
+  let(:host_ip) { 0x11223344 }
   let(:url_path) { '/some/path/here' }
-  let(:raw_url)  { "https://#{hostname}#{url_path}" }
-  let(:tracer)   { Trace.tracer }
+  let(:raw_url) { "https://#{hostname}#{url_path}" }
+  let(:tracer) { Trace.tracer }
   let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
 
+  def process(body, url, headers = {})
+    ENV['ZIPKIN_SERVICE_NAME'] = service_name
+    connection = Excon.new(raw_url,
+                           method: :post,
+                           middlewares: [ZipkinTracer::ExconHandler] + Excon.defaults[:middlewares]
+                          )
+    connection.request
+  end
 
   before do
-    stub_request(:get, "https://www.google.com/").
-      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:post, raw_url).to_return(:status => 200, :body => "", :headers => {})
 
     Trace.tracer = Trace::NullTracer.new
     Trace.push(trace_id)
     ::Trace.sample_rate = 1 # make sure initialized
-
-    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', "foo service name"))
+    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
     allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
   end
 
-  context 'with tracing id' do
+  shared_examples 'can make requests' do
+    # helper to check host component of annotation
+    def expect_host(host, host_ip, service_name)
+      expect(host).to be_a_kind_of(::Trace::Endpoint)
+      expect(host.ipv4).to eq(host_ip)
+      expect(host.service_name).to eq(service_name)
+    end
 
-    it 'sets the X-B3 request headers with a new spanID' do
-      connection = Excon.new("https://www.google.com/",
-                      method: :get,
-                      middlewares: [ZipkinTracer::ExconHandler] + Excon.defaults[:middlewares]
-                   )
-      connection.request
+    def expect_tracing
+      expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
 
-      headers = {
-        'X-B3-TraceId' => '0000000000000001',
-        'X-B3-ParentSpanId' => '0000000000000003',
-        # 'X-B3-SpanId']).not_to eq('0000000000000003')
-        # 'X-B3-SpanId']).to match(HEX_REGEX)
-        'X-B3-Sampled' => 'true',
-        'X-B3-Flags' => '1',
-      }
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('http.path')
+        expect(value).to eq(url_path)
+        expect_host(host, '127.0.0.1', service_name)
+      end
 
-      expect(a_request(:get, "https://www.google.com/").
-             with(headers: headers)).to have_been_made
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('sa')
+        expect(value).to eq('1')
+        expect(type).to eq('BOOL')
+        expect_host(host, hostname, service_name)
+      end
+
+      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+        expect(key).to eq('http.status')
+        expect(value).to eq('200')
+        expect_host(host, '127.0.0.1', service_name)
+      end
+
+      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+        expect(value).to eq(Trace::Annotation::CLIENT_SEND)
+        expect_host(host, '127.0.0.1', service_name)
+      end
+
+      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+        expect(value).to eq(Trace::Annotation::CLIENT_RECV)
+        expect_host(host, '127.0.0.1', service_name)
+      end
+    end
+
+    context 'with tracing id' do
+      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+
+      it 'sets the X-B3 request headers with a new spanID' do
+        expect_tracing
+        result = nil
+        ::Trace.push(trace_id) do
+          process('', url)
+        end
+
+        expect(a_request(:post, raw_url).with { |req| 
+          req.headers['X-B3-Traceid'] == '0000000000000001' &&
+          req.headers['X-B3-Parentspanid'] == '0000000000000003' &&
+          req.headers['X-B3-Spanid'] != '0000000000000003' &&
+          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
+          req.headers['X-B3-Sampled'] == 'true' &&
+          req.headers['X-B3-Flags'] == '1'
+        }).to have_been_made
+      end
+
+      it 'the original spanID is restored after the calling the middleware' do
+        old_trace_id = Trace.id
+        ::Trace.push(trace_id) do
+          process('', url)
+        end
+        expect(::Trace.id).to eq(old_trace_id)
+      end
+    end
+
+    context 'without tracing id' do
+      after(:each) { ::Trace.pop }
+
+      it 'generates a new ID, and sets the X-B3 request headers' do
+        expect_tracing
+        process('', url)
+
+        expect(a_request(:post, raw_url).with { |req| 
+          req.headers['X-B3-Traceid'] =~ HEX_REGEX &&
+          req.headers['X-B3-Parentspanid'] =~ HEX_REGEX &&
+          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
+          req.headers['X-B3-Sampled'] =~ /(true|false)/ &&
+          req.headers['X-B3-Flags'] =~ /(1|0)/
+        }).to have_been_made
+      end
+    end
+
+    context 'Trace has not been sampled' do
+      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, false, 0) }
+
+      it 'sets the X-B3 request headers with a new spanID' do
+        result = nil
+        ::Trace.push(trace_id) do
+          process('', url)
+        end
+
+        expect(a_request(:post, raw_url).with { |req| 
+          req.headers['X-B3-Traceid'] == '0000000000000001' &&
+          req.headers['X-B3-Parentspanid'] == '0000000000000003' &&
+          req.headers['X-B3-Spanid'] != '0000000000000003' &&
+          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
+          req.headers['X-B3-Sampled'] == 'false' &&
+          req.headers['X-B3-Flags'] == '0'
+        }).to have_been_made
+      end
+
+      it 'the original spanID is restored after the calling the middleware' do
+        old_trace_id = Trace.id
+        ::Trace.push(trace_id) do
+          process('', url)
+        end
+        expect(::Trace.id).to eq(old_trace_id)
+      end
+
+      it 'does not trace the request' do
+        expect(tracer).not_to receive(:set_rpc_name)
+        expect(tracer).not_to receive(:record)
+        ::Trace.push(trace_id) do
+           process('', url)
+        end
+      end
+
+      it 'does not create any annotation' do
+        expect(Trace::BinaryAnnotation).not_to receive(:new)
+        expect(Trace::Annotation).not_to receive(:new)
+        ::Trace.push(trace_id) do
+           process('', url)
+        end
+      end
+    end
+
+    context 'when looking up hostname raises' do
+      let(:host_ip) { 0x7f000001 } # expect stubbed 'null' IP
+
+      before do
+        allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_raise(SocketError)
+      end
+
+      it 'traces with stubbed endpoint address' do
+        expect_tracing
+        process('', url)
+      end
+    end
+
+  end
+
+
+  context 'middleware configured (without service_name)' do
+    let(:service_name) { 'service2' }
+
+    context 'request with string URL' do
+      let(:url) { raw_url }
+
+      include_examples 'can make requests'
+    end
+
+    context 'request with pre-parsed URL' do
+      let(:url) { URI.parse(raw_url) }
+
+      include_examples 'can make requests'
+    end
+  end
+
+  context 'configured with service_name "foo"' do
+    let(:service_name) { 'foo' }
+
+    context 'request with pre-parsed URL' do
+      let(:url) { URI.parse(raw_url) }
+
+      include_examples 'can make requests'
     end
   end
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'zipkin-tracer/zipkin_null_tracer'
+
+describe ZipkinTracer::ExconHandler do
+  let(:response_env) { { status: 200 } }
+  let(:wrapped_app) { lambda { |env| ResponseObject.new(env, response_env) } }
+
+  let(:hostname) { 'service.example.com' }
+  let(:host_ip) { 0x11223344 }
+  let(:url_path) { '/some/path/here' }
+  let(:raw_url) { "https://#{hostname}#{url_path}" }
+  let(:tracer) { Trace.tracer }
+  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+
+  before do
+    Excon.defaults[:middlewares].unshift(ZipkinTracer::ExconHandler)
+    Excon.defaults[:mock] = true
+    Excon.stub({ path: '/' }, body: 'index')
+    Excon.stub({ path: '/hello' }, body: 'world')
+    Excon.stub({ path: '/hello', query: 'message=world' }, body: 'hi!')
+    Excon.stub({ path: '/world' }, body: 'universe')
+
+    Trace.tracer = Trace::NullTracer.new
+    Trace.push(trace_id)
+    ::Trace.sample_rate = 1 # make sure initialized
+    service_name = "foo service name"
+    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
+    allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
+  end
+
+  it 'should do something' do
+    connection = Excon.new(raw_url)
+    response = connection.get
+
+    assert_equal 'world', response.body
+  end
+end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -6,7 +6,6 @@ describe ZipkinTracer::ExconHandler do
   # returns the request headers
   def process(body, url, headers = {})
     stub_request(:post, url).to_return(status: 200, body: body, headers: headers)
-    ENV['ZIPKIN_SERVICE_NAME'] = service_name
 
     connection = Excon.new(url.to_s,
                            body: body,
@@ -35,7 +34,7 @@ describe ZipkinTracer::ExconHandler do
   end
 
   context 'middleware configured (without service_name)' do
-    let(:service_name) { 'service' }
+    let(:service_name) { URI(url).host }
 
     context 'request with string URL' do
       let(:url) { raw_url }
@@ -51,7 +50,7 @@ describe ZipkinTracer::ExconHandler do
   end
 
   context 'configured with service_name "foo"' do
-    let(:service_name) { 'foo' }
+    let(:service_name) { url.host }
 
     context 'request with pre-parsed URL' do
       let(:url) { URI.parse(raw_url) }

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -1,184 +1,41 @@
 require 'spec_helper'
 require 'zipkin-tracer/zipkin_null_tracer'
+require 'lib/middleware_shared_examples'
 
 describe ZipkinTracer::ExconHandler do
-  HEX_REGEX = /\A\h{16}\z/
-
-  let(:hostname) { 'service.example.com' }
-  let(:host_ip) { 0x11223344 }
-  let(:url_path) { '/some/path/here' }
-  let(:raw_url) { "https://#{hostname}#{url_path}" }
-  let(:tracer) { Trace.tracer }
-  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
-
+  # returns the request headers
   def process(body, url, headers = {})
+    stub_request(:post, url).to_return(status: 200, body: body, headers: headers)
     ENV['ZIPKIN_SERVICE_NAME'] = service_name
-    connection = Excon.new(raw_url,
+
+    connection = Excon.new(url.to_s,
+                           body: body,
                            method: :post,
+                           headers: headers,
                            middlewares: [ZipkinTracer::ExconHandler] + Excon.defaults[:middlewares]
                           )
     connection.request
+
+    request_headers = nil
+    expect(a_request(:post, url).with { |req| 
+      # Webmock 'normalizes' the headers. E.g: X-B3-TraceId becomes X-B3-Traceid.
+      # See here:
+      # https://github.com/bblimke/webmock/blob/a4aad22adc622699a8ea14c70d04acef8f67a512/lib/webmock/util/headers.rb#L9
+      # So here, headers are manually fetched.
+      request_headers = {
+        'X-B3-TraceId' => req.headers['X-B3-Traceid'],
+        'X-B3-ParentSpanId' => req.headers['X-B3-Parentspanid'],
+        'X-B3-SpanId' => req.headers['X-B3-Spanid'],
+        'X-B3-Sampled' => req.headers['X-B3-Sampled'],
+        'X-B3-Flags' => req.headers['X-B3-Flags']
+      }
+    }).to have_been_made
+
+    request_headers
   end
-
-  before do
-    stub_request(:post, raw_url).to_return(:status => 200, :body => "", :headers => {})
-
-    Trace.tracer = Trace::NullTracer.new
-    Trace.push(trace_id)
-    ::Trace.sample_rate = 1 # make sure initialized
-    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
-    allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
-  end
-
-  shared_examples 'can make requests' do
-    # helper to check host component of annotation
-    def expect_host(host, host_ip, service_name)
-      expect(host).to be_a_kind_of(::Trace::Endpoint)
-      expect(host.ipv4).to eq(host_ip)
-      expect(host.service_name).to eq(service_name)
-    end
-
-    def expect_tracing
-      expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('http.path')
-        expect(value).to eq(url_path)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('sa')
-        expect(value).to eq('1')
-        expect(type).to eq('BOOL')
-        expect_host(host, hostname, service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('http.status')
-        expect(value).to eq('200')
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-        expect(value).to eq(Trace::Annotation::CLIENT_SEND)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-        expect(value).to eq(Trace::Annotation::CLIENT_RECV)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-    end
-
-    context 'with tracing id' do
-      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
-
-      it 'sets the X-B3 request headers with a new spanID' do
-        expect_tracing
-        result = nil
-        ::Trace.push(trace_id) do
-          process('', url)
-        end
-
-        expect(a_request(:post, raw_url).with { |req| 
-          req.headers['X-B3-Traceid'] == '0000000000000001' &&
-          req.headers['X-B3-Parentspanid'] == '0000000000000003' &&
-          req.headers['X-B3-Spanid'] != '0000000000000003' &&
-          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
-          req.headers['X-B3-Sampled'] == 'true' &&
-          req.headers['X-B3-Flags'] == '1'
-        }).to have_been_made
-      end
-
-      it 'the original spanID is restored after the calling the middleware' do
-        old_trace_id = Trace.id
-        ::Trace.push(trace_id) do
-          process('', url)
-        end
-        expect(::Trace.id).to eq(old_trace_id)
-      end
-    end
-
-    context 'without tracing id' do
-      after(:each) { ::Trace.pop }
-
-      it 'generates a new ID, and sets the X-B3 request headers' do
-        expect_tracing
-        process('', url)
-
-        expect(a_request(:post, raw_url).with { |req| 
-          req.headers['X-B3-Traceid'] =~ HEX_REGEX &&
-          req.headers['X-B3-Parentspanid'] =~ HEX_REGEX &&
-          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
-          req.headers['X-B3-Sampled'] =~ /(true|false)/ &&
-          req.headers['X-B3-Flags'] =~ /(1|0)/
-        }).to have_been_made
-      end
-    end
-
-    context 'Trace has not been sampled' do
-      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, false, 0) }
-
-      it 'sets the X-B3 request headers with a new spanID' do
-        result = nil
-        ::Trace.push(trace_id) do
-          process('', url)
-        end
-
-        expect(a_request(:post, raw_url).with { |req| 
-          req.headers['X-B3-Traceid'] == '0000000000000001' &&
-          req.headers['X-B3-Parentspanid'] == '0000000000000003' &&
-          req.headers['X-B3-Spanid'] != '0000000000000003' &&
-          req.headers['X-B3-Spanid'] =~ HEX_REGEX &&
-          req.headers['X-B3-Sampled'] == 'false' &&
-          req.headers['X-B3-Flags'] == '0'
-        }).to have_been_made
-      end
-
-      it 'the original spanID is restored after the calling the middleware' do
-        old_trace_id = Trace.id
-        ::Trace.push(trace_id) do
-          process('', url)
-        end
-        expect(::Trace.id).to eq(old_trace_id)
-      end
-
-      it 'does not trace the request' do
-        expect(tracer).not_to receive(:set_rpc_name)
-        expect(tracer).not_to receive(:record)
-        ::Trace.push(trace_id) do
-           process('', url)
-        end
-      end
-
-      it 'does not create any annotation' do
-        expect(Trace::BinaryAnnotation).not_to receive(:new)
-        expect(Trace::Annotation).not_to receive(:new)
-        ::Trace.push(trace_id) do
-           process('', url)
-        end
-      end
-    end
-
-    context 'when looking up hostname raises' do
-      let(:host_ip) { 0x7f000001 } # expect stubbed 'null' IP
-
-      before do
-        allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_raise(SocketError)
-      end
-
-      it 'traces with stubbed endpoint address' do
-        expect_tracing
-        process('', url)
-      end
-    end
-
-  end
-
 
   context 'middleware configured (without service_name)' do
-    let(:service_name) { 'service2' }
+    let(:service_name) { 'service' }
 
     context 'request with string URL' do
       let(:url) { raw_url }

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -2,34 +2,42 @@ require 'spec_helper'
 require 'zipkin-tracer/zipkin_null_tracer'
 
 describe ZipkinTracer::ExconHandler do
-  let(:response_env) { { status: 200 } }
-  let(:wrapped_app) { lambda { |env| ResponseObject.new(env, response_env) } }
-
   let(:hostname) { 'service.example.com' }
-  let(:host_ip) { 0x11223344 }
+  let(:host_ip)  { 0x11223344 }
   let(:url_path) { '/some/path/here' }
-  let(:raw_url) { "https://#{hostname}#{url_path}" }
-  let(:tracer) { Trace.tracer }
+  let(:raw_url)  { "https://#{hostname}#{url_path}" }
+  let(:tracer)   { Trace.tracer }
   let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
 
-  before do
-    Excon.defaults[:middlewares].unshift(ZipkinTracer::ExconHandler)
-    Excon.defaults[:mock] = true
 
-    Excon.stub({ path: url_path }, body: 'world')
+  before do
+    # Excon.defaults[:mock] = true
+    # Excon.stub({ path: url_path }, body: 'world')
 
     Trace.tracer = Trace::NullTracer.new
     Trace.push(trace_id)
     ::Trace.sample_rate = 1 # make sure initialized
-    service_name = "foo service name"
-    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
+
+    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', "foo service name"))
     allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
   end
 
-  it 'should do something' do
-    connection = Excon.new(raw_url)
-    response = connection.get
+  context 'with tracing id' do
+    let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
 
-    expect(response.body).to eq('world')
+    it 'sets the X-B3 request headers with a new spanID' do
+      connection = Excon.new("https://www.google.com/",
+                      method: :get,
+                      middlewares: Excon.defaults[:middlewares] + [ZipkinTracer::ExconHandler]
+                   )
+      response = connection.request
+
+      expect(request.data[:headers]['X-B3-TraceId']).to eq('0000000000000001')
+      expect(request.data[:headers]['X-B3-ParentSpanId']).to eq('0000000000000003')
+      expect(request.data[:headers]['X-B3-SpanId']).not_to eq('0000000000000003')
+      expect(request.data[:headers]['X-B3-SpanId']).to match(HEX_REGEX)
+      expect(request.data[:headers]['X-B3-Sampled']).to eq('true')
+      expect(request.data[:headers]['X-B3-Flags']).to eq('1')
+    end
   end
 end

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'zipkin-tracer/zipkin_null_tracer'
+require 'lib/middleware_shared_examples'
 
 describe ZipkinTracer::FaradayHandler do
   # allow stubbing of on_complete and response env
@@ -17,18 +18,10 @@ describe ZipkinTracer::FaradayHandler do
     end
   end
 
-  HEX_REGEX = /\A\h{16}\z/
-
   let(:response_env) { { status: 200 } }
   let(:wrapped_app) { lambda { |env| ResponseObject.new(env, response_env) } }
 
-  let(:hostname) { 'service.example.com' }
-  let(:host_ip) { 0x11223344 }
-  let(:url_path) { '/some/path/here' }
-  let(:raw_url) { "https://#{hostname}#{url_path}" }
-  let(:tracer) { Trace.tracer }
-  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
-
+  # returns the request headers
   def process(body, url, headers = {})
     env = {
       method: :post,
@@ -36,156 +29,8 @@ describe ZipkinTracer::FaradayHandler do
       body: body,
       request_headers: {}, #Faraday::Utils::Headers.new(headers),
     }
-    middleware.call(env)
+    middleware.call(env).env[:request_headers]
   end
-
-  before do
-    Trace.tracer = Trace::NullTracer.new
-    Trace.push(trace_id)
-    ::Trace.sample_rate = 1 # make sure initialized
-    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
-    allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
-  end
-
-  shared_examples 'can make requests' do
-    # helper to check host component of annotation
-    def expect_host(host, host_ip, service_name)
-      expect(host).to be_a_kind_of(::Trace::Endpoint)
-      expect(host.ipv4).to eq(host_ip)
-      expect(host.service_name).to eq(service_name)
-    end
-
-    def expect_tracing
-      expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('http.path')
-        expect(value).to eq(url_path)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('sa')
-        expect(value).to eq('1')
-        expect(type).to eq('BOOL')
-        expect_host(host, hostname, service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-        expect(key).to eq('http.status')
-        expect(value).to eq('200')
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-        expect(value).to eq(Trace::Annotation::CLIENT_SEND)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-
-      expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-        expect(value).to eq(Trace::Annotation::CLIENT_RECV)
-        expect_host(host, '127.0.0.1', service_name)
-      end
-    end
-
-    context 'with tracing id' do
-      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
-
-      it 'sets the X-B3 request headers with a new spanID' do
-        expect_tracing
-        result = nil
-        ::Trace.push(trace_id) do
-          result = process('', url).env
-        end
-
-        expect(result[:request_headers]['X-B3-TraceId']).to eq('0000000000000001')
-        expect(result[:request_headers]['X-B3-ParentSpanId']).to eq('0000000000000003')
-        expect(result[:request_headers]['X-B3-SpanId']).not_to eq('0000000000000003')
-        expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
-        expect(result[:request_headers]['X-B3-Sampled']).to eq('true')
-        expect(result[:request_headers]['X-B3-Flags']).to eq('1')
-      end
-
-      it 'the original spanID is restored after the calling the middleware' do
-        old_trace_id = Trace.id
-        ::Trace.push(trace_id) do
-          process('', url).env
-        end
-        expect(::Trace.id).to eq(old_trace_id)
-      end
-    end
-
-    context 'without tracing id' do
-      after(:each) { ::Trace.pop }
-
-      it 'generates a new ID, and sets the X-B3 request headers' do
-        expect_tracing
-        result = process('', url).env
-        expect(result[:request_headers]['X-B3-TraceId']).to match(HEX_REGEX)
-        expect(result[:request_headers]['X-B3-ParentSpanId']).to match(HEX_REGEX)
-        expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
-        expect(result[:request_headers]['X-B3-Sampled']).to match(/(true|false)/)
-        expect(result[:request_headers]['X-B3-Flags']).to match(/(1|0)/)
-      end
-    end
-
-    context 'Trace has not been sampled' do
-      let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, false, 0) }
-
-      it 'sets the X-B3 request headers with a new spanID' do
-        result = nil
-        ::Trace.push(trace_id) do
-          result = process('', url).env
-        end
-
-        expect(result[:request_headers]['X-B3-TraceId']).to eq('0000000000000001')
-        expect(result[:request_headers]['X-B3-ParentSpanId']).to eq('0000000000000003')
-        expect(result[:request_headers]['X-B3-SpanId']).not_to eq('0000000000000003')
-        expect(result[:request_headers]['X-B3-SpanId']).to match(HEX_REGEX)
-        expect(result[:request_headers]['X-B3-Sampled']).to eq('false')
-        expect(result[:request_headers]['X-B3-Flags']).to eq('0')
-      end
-
-      it 'the original spanID is restored after the calling the middleware' do
-        old_trace_id = Trace.id
-        ::Trace.push(trace_id) do
-          process('', url).env
-        end
-        expect(::Trace.id).to eq(old_trace_id)
-      end
-
-      it 'does not trace the request' do
-        expect(tracer).not_to receive(:set_rpc_name)
-        expect(tracer).not_to receive(:record)
-        ::Trace.push(trace_id) do
-           process('', url).env
-        end
-      end
-
-      it 'does not create any annotation' do
-        expect(Trace::BinaryAnnotation).not_to receive(:new)
-        expect(Trace::Annotation).not_to receive(:new)
-        ::Trace.push(trace_id) do
-           process('', url).env
-        end
-      end
-    end
-
-    context 'when looking up hostname raises' do
-      let(:host_ip) { 0x7f000001 } # expect stubbed 'null' IP
-
-      before do
-        allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_raise(SocketError)
-      end
-
-      it 'traces with stubbed endpoint address' do
-        expect_tracing
-        process('', url)
-      end
-    end
-
-  end
-
 
   context 'middleware configured (without service_name)' do
     let(:middleware) { described_class.new(wrapped_app) }

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -1,0 +1,155 @@
+HEX_REGEX = /\A\h{16}\z/
+
+shared_examples 'can make requests' do
+  before do
+    Trace.tracer = Trace::NullTracer.new
+    Trace.push(trace_id)
+    ::Trace.sample_rate = 1 # make sure initialized
+    allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
+    allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
+  end
+
+  let(:hostname) { 'service.example.com' }
+  let(:host_ip) { 0x11223344 }
+  let(:url_path) { '/some/path/here' }
+  let(:raw_url) { "https://#{hostname}#{url_path}" }
+  let(:tracer) { Trace.tracer }
+  let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+
+  # helper to check host component of annotation
+  def expect_host(host, host_ip, service_name)
+    expect(host).to be_a_kind_of(::Trace::Endpoint)
+    expect(host.ipv4).to eq(host_ip)
+    expect(host.service_name).to eq(service_name)
+  end
+
+  def expect_tracing
+    expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+      expect(key).to eq('http.path')
+      expect(value).to eq(url_path)
+      expect_host(host, '127.0.0.1', service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+      expect(key).to eq('sa')
+      expect(value).to eq('1')
+      expect(type).to eq('BOOL')
+      expect_host(host, hostname, service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+      expect(key).to eq('http.status')
+      expect(value).to eq('200')
+      expect_host(host, '127.0.0.1', service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+      expect(value).to eq(Trace::Annotation::CLIENT_SEND)
+      expect_host(host, '127.0.0.1', service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
+      expect(value).to eq(Trace::Annotation::CLIENT_RECV)
+      expect_host(host, '127.0.0.1', service_name)
+    end
+  end
+
+  context 'with tracing id' do
+    let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
+
+    it 'sets the X-B3 request headers with a new spanID' do
+      expect_tracing
+      request_headers  = nil
+      ::Trace.push(trace_id) do
+        request_headers = process('', url)
+      end
+
+      expect(request_headers['X-B3-TraceId']).to eq('0000000000000001')
+      expect(request_headers['X-B3-ParentSpanId']).to eq('0000000000000003')
+      expect(request_headers['X-B3-SpanId']).not_to eq('0000000000000003')
+      expect(request_headers['X-B3-SpanId']).to match(HEX_REGEX)
+      expect(request_headers['X-B3-Sampled']).to eq('true')
+      expect(request_headers['X-B3-Flags']).to eq('1')
+    end
+
+    it 'the original spanID is restored after the calling the middleware' do
+      old_trace_id = Trace.id
+      ::Trace.push(trace_id) do
+        process('', url)
+      end
+      expect(::Trace.id).to eq(old_trace_id)
+    end
+  end
+
+  context 'without tracing id' do
+    after(:each) { ::Trace.pop }
+
+    it 'generates a new ID, and sets the X-B3 request headers' do
+      expect_tracing
+      request_headers = process('', url)
+
+      expect(request_headers['X-B3-TraceId']).to match(HEX_REGEX)
+      expect(request_headers['X-B3-ParentSpanId']).to match(HEX_REGEX)
+      expect(request_headers['X-B3-SpanId']).to match(HEX_REGEX)
+      expect(request_headers['X-B3-Sampled']).to match(/(true|false)/)
+      expect(request_headers['X-B3-Flags']).to match(/(1|0)/)
+    end
+  end
+
+  context 'Trace has not been sampled' do
+    let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, false, 0) }
+
+    it 'sets the X-B3 request headers with a new spanID' do
+      request_headers = nil
+      ::Trace.push(trace_id) do
+        request_headers = process('', url)
+      end
+
+      expect(request_headers['X-B3-TraceId']).to eq('0000000000000001')
+      expect(request_headers['X-B3-ParentSpanId']).to eq('0000000000000003')
+      expect(request_headers['X-B3-SpanId']).not_to eq('0000000000000003')
+      expect(request_headers['X-B3-SpanId']).to match(HEX_REGEX)
+      expect(request_headers['X-B3-Sampled']).to eq('false')
+      expect(request_headers['X-B3-Flags']).to eq('0')
+    end
+
+    it 'the original spanID is restored after the calling the middleware' do
+      old_trace_id = Trace.id
+      ::Trace.push(trace_id) do
+        process('', url)
+      end
+      expect(::Trace.id).to eq(old_trace_id)
+    end
+
+    it 'does not trace the request' do
+      expect(tracer).not_to receive(:set_rpc_name)
+      expect(tracer).not_to receive(:record)
+      ::Trace.push(trace_id) do
+        process('', url)
+      end
+    end
+
+    it 'does not create any annotation' do
+      expect(Trace::BinaryAnnotation).not_to receive(:new)
+      expect(Trace::Annotation).not_to receive(:new)
+      ::Trace.push(trace_id) do
+        process('', url)
+      end
+    end
+  end
+
+  context 'when looking up hostname raises' do
+    let(:host_ip) { 0x7f000001 } # expect stubbed 'null' IP
+
+    before do
+      allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_raise(SocketError)
+    end
+
+    it 'traces with stubbed endpoint address' do
+      expect_tracing
+      process('', url)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'zipkin-tracer'
 require 'timecop'
 require 'webmock/rspec'
 require 'sucker_punch/testing/inline'
+require 'byebug'
 
 RSpec.configure do |config|
   config.order = :random

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require 'zipkin-tracer'
 require 'timecop'
 require 'webmock/rspec'
 require 'sucker_punch/testing/inline'
-require 'byebug'
 
 RSpec.configure do |config|
   config.order = :random

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.2'
-  s.add_dependency 'excon', '~> 0.54'
+  s.add_dependency 'excon', '~> 0.53'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.2'
-  s.add_dependency 'excon', '~> 0.53'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 
+  s.add_development_dependency 'excon', '~> 0.53'
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rake', '~> 10.0'

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'finagle-thrift', '~> 1.4.2'
+  s.add_dependency 'excon', '~> 0.54'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 
@@ -30,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop', '~> 0.8'
   s.add_development_dependency 'webmock', '~> 1.22'
+  s.add_development_dependency 'byebug'
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop', '~> 0.8'
   s.add_development_dependency 'webmock', '~> 1.22'
-  s.add_development_dependency 'byebug'
 end


### PR DESCRIPTION
Add an Excon middleware that allows to trace outgoing web requests created by [Excon](https://github.com/excon/excon), the same way `zipkin-ruby` allows to trace outboing web requests created by Faraday.