### PR TITLE
Fix filter_plugin example Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ For example:
 
 ```ruby
 # don't trace /static/ URIs
-lambda { |env| env['PATH_INFO'] ~! /^\/static\// }
+lambda { |env| env['PATH_INFO'] !~ /^\/static\// }
 ```
 
 ### whitelist_plugin


### PR DESCRIPTION
## What
Typo fix for regex negative comparison operator

## Why 
So the next person can copy/paste example code and have it work

**Thanks for a great plugin!**