### PR TITLE
Add tests for response status tracing in Excon middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.21.1
+* Bugfix: better guard against nil response in the Excon middleware
+
 # 0.21.0
 * Added an Excon middleware
 

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -70,8 +70,7 @@ module ZipkinTracer
     end
 
     def response_status(datum)
-      return nil unless datum[:response] && datum[:response][:status]
-      return datum[:response][:status].to_s
+      datum[:response] && datum[:response][:status] && datum[:response][:status].to_s
     end
 
     def trace!(datum, trace_id)

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -28,10 +28,15 @@ module ZipkinTracer
     end
 
     def response_call(datum)
-      response = datum[:response]
-
       if span = datum[:span]
-        span.record_tag(Trace::BinaryAnnotation::STATUS, response[:status].to_s, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
+        if status = response_status(datum)
+          span.record_tag(
+            Trace::BinaryAnnotation::STATUS,
+            status,
+            Trace::BinaryAnnotation::Type::STRING,
+            local_endpoint
+          )
+        end
         span.record(Trace::Annotation::CLIENT_RECV, local_endpoint)
       end
 
@@ -62,6 +67,11 @@ module ZipkinTracer
 
     def service_name(datum, default)
       datum.fetch(:zipkin_service_name, default)
+    end
+
+    def response_status(datum)
+      return nil unless datum[:response] && datum[:response][:status]
+      return datum[:response][:status].to_s
     end
 
     def trace!(datum, trace_id)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.21.0'.freeze
+  VERSION = '0.21.1'.freeze
 end


### PR DESCRIPTION
Test the response status is correctly traced.  Also guard against nil
response/status, which might happen if the middleware is inserted into
Excon before the Excon::Middleware::ResponseParser.