### PR TITLE
Prevents raising an error if the tracer is not set in Faraday and Excon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.21.2
+* Bugfix: Guard against tracer not set in Faraday and Excon middlewares
+
 # 0.21.1
 * Bugfix: better guard against nil response in the Excon middleware
 

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -21,7 +21,7 @@ module ZipkinTracer
           datum[:headers][header] = trace_id.send(method).to_s
         end
 
-        trace!(datum, trace_id) if trace_id.sampled?
+        trace!(datum, trace_id) if Trace.tracer && trace_id.sampled?
       end
 
       super(datum)

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -17,7 +17,7 @@ module ZipkinTracer
         b3_headers.each do |method, header|
           env[:request_headers][header] = trace_id.send(method).to_s
         end
-        if trace_id.sampled?
+        if Trace.tracer && trace_id.sampled?
           trace!(env, trace_id)
         else
           @app.call(env)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.21.1'.freeze
+  VERSION = '0.21.2'.freeze
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -39,13 +39,15 @@ describe ZipkinTracer::ExconHandler do
     context 'request with string URL' do
       let(:url) { raw_url }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
 
     context 'request with pre-parsed URL' do
       let(:url) { URI.parse(raw_url) }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
   end
 
@@ -55,7 +57,8 @@ describe ZipkinTracer::ExconHandler do
     context 'request with pre-parsed URL' do
       let(:url) { URI.parse(raw_url) }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
 
     context 'request with path and query params' do

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -39,14 +39,16 @@ describe ZipkinTracer::FaradayHandler do
     context 'request with string URL' do
       let(:url) { raw_url }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
 
     # in testing, Faraday v0.8.x passes a URI object rather than a string
     context 'request with pre-parsed URL' do
       let(:url) { URI.parse(raw_url) }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
   end
 
@@ -58,7 +60,8 @@ describe ZipkinTracer::FaradayHandler do
     context 'request with pre-parsed URL' do
       let(:url) { URI.parse(raw_url) }
 
-      include_examples 'can make requests'
+      include_examples 'makes requests with tracing'
+      include_examples 'makes requests without tracing'
     end
   end
 end


### PR DESCRIPTION
Also reworked the specs to test the case when we add headers but do not trace 
@adriancole 