### PR TITLE
Add the `:record_on_server_receive` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.22.0
+* Add the `:record_on_server_receive` configuration option.
+
 # 0.21.2
 * Bugfix: Guard against tracer not set in Faraday and Excon middlewares
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
+* `:record_on_server_receive` - a CSV style list of tags to record on server receive, even if the zipkin headers were present in the incoming request. Currently only supports the value `http.path`, others being discarded.
 
 ### Sending traces on outgoing requests with Faraday
 
@@ -179,7 +180,7 @@ lambda { |env| KNOWN_DEVICES.include?(env['HTTP_X_DEVICE_ID']) }
 ## Development
 
 This project uses Rspec. Make sure your PRs contain proper tests.
-We have two rake task to help finding performance issues:
+We have two rake tasks to help finding performance issues:
 ```
 rake benchmark
 ```

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'zipkin-tracer/application'
+require 'zipkin-tracer/rack/zipkin-tracer'
 
 module ZipkinTracer
   # Configuration of this gem. It reads the configuration and provides default values
@@ -7,7 +8,7 @@ module ZipkinTracer
     attr_reader :service_name, :service_port, :json_api_host,
       :zookeeper, :sample_rate, :logger, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin,
-      :sampled_as_boolean
+      :sampled_as_boolean, :record_on_server_receive
 
     def initialize(app, config_hash)
       config = config_hash || Application.config(app)
@@ -30,7 +31,6 @@ module ZipkinTracer
       # A block of code which can be called to force sampling. Forces sampling if returns true
       @whitelist_plugin  = config[:whitelist_plugin]
       @logger            = Application.logger
-      @log_tracing       = config[:log_tracing]       # Was the logger in fact setup by the client?
       # Was the logger in fact setup by the client?
       @log_tracing       = config[:log_tracing]
       # When set to false, it uses 1/0 in the 'X-B3-Sampled' header, else uses true/false
@@ -39,6 +39,10 @@ module ZipkinTracer
       if @sampled_as_boolean
         @logger && @logger.warn("Using a boolean in the Sampled header is deprecated. Consider setting sampled_as_boolean to false")
       end
+      # Record the given tags on server receive, even if the zipkin headers were present in the incoming request?
+      tags = config[:record_on_server_receive]
+      @record_on_server_receive = present?(tags) ? parse_record_on_server_receive(tags) : nil
+
       Trace.sample_rate = @sample_rate
     end
 
@@ -61,6 +65,15 @@ module ZipkinTracer
       service_port: 80,
       sampled_as_boolean: true
     }
+
+    def parse_record_on_server_receive(tag_names)
+      names = tag_names.split(",").map(&:strip)
+      tags = {}
+      (ZipkinTracer::RackHandler::DEFAULT_SERVER_RECV_TAGS.keys & names).each do |name|
+        tags[name] = ZipkinTracer::RackHandler::DEFAULT_SERVER_RECV_TAGS[name]
+      end
+      tags.empty? ? nil : tags
+    end
 
     def present?(str)
       return false if str.nil?

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -50,8 +50,8 @@ module ZipkinTracer
     def trace!(span, zipkin_env, &block)
       # if the request comes from a non zipkin-enabled source record the default tags
       tags = DEFAULT_SERVER_RECV_TAGS unless zipkin_env.called_with_zipkin_headers?
-      # if the user specified tags to record on server recv, use these no matter what
-      tags = @config.record_on_server_receive if @config.record_on_server_receive
+      # if the user specified tags to record on server receive, use these no matter what
+      tags = @config.record_on_server_receive unless @config.record_on_server_receive.empty?
       trace_request_information(span, zipkin_env.env, tags)
 
       span.record(Trace::Annotation::SERVER_RECV)
@@ -63,6 +63,8 @@ module ZipkinTracer
     end
 
     def trace_request_information(span, env, tags)
+      # tags is nil if we've been called by a zipkin-enabled service and the user hasn't
+      # specified tags to record on server receive.
       return if tags.nil?
       tags.each { |annotation_key, env_key| span.record_tag(annotation_key, env[env_key]) }
     end

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -1,3 +1,4 @@
+require 'rack'
 require 'finagle-thrift/trace'
 require 'finagle-thrift/tracer'
 require 'zipkin-tracer/config'
@@ -8,6 +9,14 @@ module ZipkinTracer
   # This middleware reads Zipkin headers from the request and sets/creates a Trace.id usable by the rest of the app
   # It will also send the trace to the Zipkin service using one of the methods configured.
   class RackHandler
+    # the following constants are defined only from rack 1.6
+    PATH_INFO = Rack::PATH_INFO rescue 'PATH_INFO'.freeze
+    REQUEST_METHOD = Rack::REQUEST_METHOD rescue 'REQUEST_METHOD'.freeze
+
+    DEFAULT_SERVER_RECV_TAGS = {
+     Trace::BinaryAnnotation::PATH => PATH_INFO
+    }.freeze
+
     def initialize(app, config = nil)
       @app = app
       @config = Config.new(app, config).freeze
@@ -21,7 +30,7 @@ module ZipkinTracer
         if !trace_id.sampled? || !routable_request?(env)
           @app.call(env)
         else
-          @tracer.with_new_span(trace_id, env['REQUEST_METHOD'].to_s.downcase) do |span|
+          @tracer.with_new_span(trace_id, env[REQUEST_METHOD].to_s.downcase) do |span|
             trace!(span, zipkin_env) { @app.call(env) }
           end
         end
@@ -31,7 +40,7 @@ module ZipkinTracer
     private
 
     def routable_request?(env)
-      Application.routable_request?(env['PATH_INFO'],  env['REQUEST_METHOD'])
+      Application.routable_request?(env[PATH_INFO],  env[REQUEST_METHOD])
     end
 
     def annotate_plugin(env, status, response_headers, response_body)
@@ -39,8 +48,12 @@ module ZipkinTracer
     end
 
     def trace!(span, zipkin_env, &block)
-      # if called by a service, the caller already added the information
-      trace_request_information(span, zipkin_env.env) unless zipkin_env.called_with_zipkin_headers?
+      # if the request comes from a non zipkin-enabled source record the default tags
+      tags = DEFAULT_SERVER_RECV_TAGS unless zipkin_env.called_with_zipkin_headers?
+      # if the user specified tags to record on server recv, use these no matter what
+      tags = @config.record_on_server_receive if @config.record_on_server_receive
+      trace_request_information(span, zipkin_env.env, tags)
+
       span.record(Trace::Annotation::SERVER_RECV)
       span.record('whitelisted') if zipkin_env.force_sample?
       status, headers, body = yield
@@ -49,8 +62,9 @@ module ZipkinTracer
       span.record(Trace::Annotation::SERVER_SEND)
     end
 
-    def trace_request_information(span, env)
-      span.record_tag(Trace::BinaryAnnotation::PATH, env['PATH_INFO'])
+    def trace_request_information(span, env, tags)
+      return if tags.nil?
+      tags.each { |annotation_key, env_key| span.record_tag(annotation_key, env[env_key]) }
     end
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.21.2'.freeze
+  VERSION = '0.22.0'.freeze
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license                   = 'Apache'
 
   s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version     = '>= 2.0.0'
 
   s.files                     = Dir.glob('{bin,lib}/**/*')
   s.require_path              = 'lib'
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop', '~> 0.8'
-  s.add_development_dependency 'webmock', '~> 1.22'
+  s.add_development_dependency 'webmock', '~> 3.0'
 end


### PR DESCRIPTION
This adds a new configuration option to force the sending of path info on server receive.
Usually it is not needed because it's provided by the client but we have a use case here that requires that data to be sent (in a nutshell some service processing zipkin data to compute metrics).

@jcarres-mdsol @adriancole 