### PR TITLE
add sidekiq middleware for tracing sidekiq jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.22.1
+* Add sidekiq worker tracing.
+
 # 0.22.0
 * Add the `:record_on_server_receive` configuration option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.22.1
+# 0.23.0
 * Add sidekiq worker tracing.
 
 # 0.22.0

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ Note that supplying the service name for the destination service is optional;
 the tracing will default to a service name derived from the first section of the destination URL (e.g. 'service.example.com' => 'service').
 
 
+### Tracing Sidekiq workers
+
+Sidekiq tracing can be turned on by adding ZipkinTracer::Sidekiq::Middleware to your sidekiq middleware chain:
+
+```ruby
+zipkin_tracer_config = {
+  service_name: 'service',
+  service_port: 3000,
+  json_api_host: 'http://zipkin.io',
+  traceable_workers: [:MyWorker, :MyWorker2],
+  sample_rate: 0.5
+}
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add ZipkinTracer::Sidekiq::Middleware, zipkin_tracer_config
+  end
+end
+```
+
+By default workers aren't traced. You can specify the workers that you want to trace with traceable_workers config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all]).
+
 ### Local tracing
 
 `ZipkinTracer::TraceClient` provides an API to record local traces in your application.

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,6 +1,7 @@
 require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
+require 'zipkin-tracer/sidekiq/middleware'
 require 'zipkin-tracer/trace_client'
 require 'zipkin-tracer/trace_container'
 require 'zipkin-tracer/trace_generator'

--- a/lib/zipkin-tracer/sidekiq/middleware.rb
+++ b/lib/zipkin-tracer/sidekiq/middleware.rb
@@ -1,0 +1,47 @@
+module ZipkinTracer
+  module Sidekiq
+    class Middleware
+      attr_reader :config, :tracer, :traceable_workers
+
+      def initialize(config)
+        @config = Config.new(nil, config).freeze
+        @tracer = TracerFactory.new.tracer(@config)
+        @traceable_workers = config.fetch(:traceable_workers, [])
+      end
+
+      def call(worker, job, queue, &block)
+        return block.call unless traceable_worker?(worker)
+
+        trace(worker, job, queue, &block)
+      end
+
+      private
+
+      def traceable_worker?(worker)
+        traceable_workers.include?(:all) || traceable_workers.include?(worker_name(worker))
+      end
+
+      def trace(worker, job, queue, &block)
+        trace_id = TraceGenerator.new.next_trace_id
+        span_name = worker_name(worker)
+
+        result = TraceContainer.with_trace_id(trace_id) do
+          if trace_id.sampled?
+            tracer.with_new_span(trace_id, span_name) do
+              result = block.call
+            end
+          else
+            result = block.call
+          end
+        end
+
+        tracer.flush!
+        result
+      end
+
+      def worker_name(worker)
+        worker.class.to_s.to_sym
+      end
+    end
+  end
+end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.22.0'.freeze
+  VERSION = '0.22.1'.freeze
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.22.1'.freeze
+  VERSION = '0.23.0'.freeze
 end

--- a/spec/lib/sidekiq/middleware_spec.rb
+++ b/spec/lib/sidekiq/middleware_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe ZipkinTracer::Sidekiq::Middleware do
+
+  describe 'call' do
+    subject { described_class.new(config) }
+    let(:job) { "test_job" }
+    let(:queue) { "test_queue" }
+
+    context 'with traceable_workers config option' do
+      let(:worker) { "worker" }
+      let(:config) do
+        {
+          service_name: 'test_service',
+          service_port: 3000,
+          traceable_workers: [ :String ]
+        }
+      end
+
+      it 'traces worker that is specified in config' do
+        expect(subject).to receive(:trace)
+
+        subject.call(worker, job, queue) { 2 + 2 }
+      end
+
+      it 'does not trace worker that is not specified in config' do
+        expect(subject).not_to receive(:trace)
+
+        subject.call(5, job, queue) { 2 + 2 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added [sidekiq middleware](https://github.com/mperham/sidekiq/wiki/Middleware) for tracing background jobs

The tracing can be turned on by adding ZipkinTracer::Sidekiq::Middleware to your sidekiq middleware chain

```
zipkin_tracer_config = {
  service_name: 'service',
  service_port: 3000,
  json_api_host: 'http://zipkin.io',
  traceable_workers: [:MyWorker, :MyWorker2],
  sample_rate: 0.5
}

Sidekiq.configure_server do |config|
  config.server_middleware do |chain|
    chain.add ::ZipkinTracer::Sidekiq::Middleware, zipkin_tracer_config
  end
end
```
You can specify the workers that you want to trace with **traceable_workers** config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all])
