### PR TITLE
Fix excon span duration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.23.0
+* Fix Excon middleware span duration
+* Add `start_span` and `end_span` to the Null tracer
+
 # 0.22.0
 * Add the `:record_on_server_receive` configuration option.
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.22.0'.freeze
+  VERSION = '0.23.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_null_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_null_tracer.rb
@@ -4,8 +4,19 @@ module Trace
   # the NullTracer also.
   class NullTracer
     def with_new_span(trace_id, name)
-      span = Span.new(name, trace_id)
-      yield span
+      span = start_span(trace_id, name)
+      result = yield span
+      end_span(span)
+      result
+    end
+
+    def start_span(trace_id, name)
+      # NOOP
+      Span.new(name, trace_id)
+    end
+
+    def end_span(span)
+      # NOOP
     end
 
     def flush!

--- a/lib/zipkin-tracer/zipkin_null_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_null_tracer.rb
@@ -11,12 +11,11 @@ module Trace
     end
 
     def start_span(trace_id, name)
-      # NOOP
       Span.new(name, trace_id)
     end
 
     def end_span(span)
-      # NOOP
+      span.close if span.respond_to?(:close)
     end
 
     def flush!

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -51,6 +51,34 @@ describe ZipkinTracer::ExconHandler do
     end
   end
 
+  it 'has a trace with correct duration' do
+    Trace.tracer = Trace::NullTracer.new
+    ::Trace.sample_rate = 1
+    trace_id = ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG)
+    url = 'https://www.example.com'
+    allow(::Trace).to receive(:default_endpoint)
+      .and_return(::Trace::Endpoint.new('127.0.0.1', '80', 'example.com'))
+    stub_request(:post, url)
+      .to_return(body: lambda { |request| sleep 1; '' })
+    connection = Excon.new(url.to_s,
+                          body: '',
+                          method: :post,
+                          headers: {},
+                          middlewares: [ZipkinTracer::ExconHandler] + Excon.defaults[:middlewares]
+                          )
+
+    span = Trace::Span.new('span', trace_id)
+    allow(Trace::Span).to receive(:new).and_return(span)
+    allow(span).to receive(:close).and_call_original
+
+    ::Trace.push(trace_id) do
+      connection.request
+    end
+
+    expect(span).to have_received(:close)
+    expect(span.to_h[:duration]).to be > 1_000_000
+  end
+
   context 'configured with service_name "foo"' do
     let(:service_name) { url.host }
 

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -48,7 +48,8 @@ shared_examples 'make requests' do |expect_to_trace_request|
   end
 
   def expect_tracing
-    expect(tracer).to receive(:with_new_span).with(anything, 'post').and_call_original
+    expect(tracer).to receive(:start_span).with(anything, 'post').and_call_original
+    expect(tracer).to receive(:end_span).with(anything).and_call_original
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
       expect(key).to eq('http.path')


### PR DESCRIPTION
Because of the way the middlewares in Excon works, we have to split the `with_new_span` call to `start_span` in the request part of the middleware and `end_span` in the response part.

This also changes the specs to ensure we call start and end directly. And add those methods to the null tracer.