### PR TITLE
[FIX] pass and use the span in annotate_plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.24.0
+* Fix Pass and use the span in annotate_plugin
+
 # 0.23.0
 * Fix Excon middleware span duration
 * Add `start_span` and `end_span` to the Null tracer

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Thus, if you only want to generate IDs for instance for logging and do not inten
 The annotate plugin expects a function of the form:
 
 ```ruby
-lambda { |env, status, response_headers, response_body| ... }
+lambda { |span, env, status, response_headers, response_body| ... }
 ```
 
 The annotate plugin is expected to perform annotation based on content of the Rack environment and the response components.
@@ -135,13 +135,13 @@ The return value is ignored.
 For example:
 
 ```ruby
-lambda do |env, status, response_headers, response_body|
+lambda do |span, env, status, response_headers, response_body|
   ep = ::Trace.default_endpoint
   # string annotation
-  ::Trace.record(::Trace::BinaryAnnotation.new('http.referrer', env['HTTP_REFERRER'], 'STRING', ep))
+  span.record_tag('http.referrer', env['HTTP_REFERRER'])
   # integer annotation
-  ::Trace.record(::Trace::BinaryAnnotation.new('http.content_size', [env['CONTENT_SIZE']].pack('N'), 'I32', ep))
-  ::Trace.record(::Trace::BinaryAnnotation.new('http.status', [status.to_i].pack('n'), 'I16', ep))
+  span.record_tag('http.content_size', [env['CONTENT_SIZE']].pack('N'), Trace::BinaryAnnotation::Type::I32, ep)
+  span.record_tag('http.status', [status.to_i].pack('n'), Trace::BinaryAnnotation::Type::I16, ep)
 end
 ```
 

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -43,8 +43,8 @@ module ZipkinTracer
       Application.routable_request?(env[PATH_INFO],  env[REQUEST_METHOD])
     end
 
-    def annotate_plugin(env, status, response_headers, response_body)
-      @config.annotate_plugin.call(env, status, response_headers, response_body) if @config.annotate_plugin
+    def annotate_plugin(span, env, status, response_headers, response_body)
+      @config.annotate_plugin.call(span, env, status, response_headers, response_body) if @config.annotate_plugin
     end
 
     def trace!(span, zipkin_env, &block)
@@ -53,7 +53,7 @@ module ZipkinTracer
       span.record('whitelisted') if zipkin_env.force_sample?
       status, headers, body = yield
     ensure
-      annotate_plugin(zipkin_env.env, status, headers, body)
+      annotate_plugin(span, zipkin_env.env, status, headers, body)
       span.record(Trace::Annotation::SERVER_SEND)
     end
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.23.0'.freeze
+  VERSION = '0.24.0'.freeze
 end


### PR DESCRIPTION
Addressing the https://github.com/openzipkin/zipkin-ruby/issues/102

Passing the span as @strom suggested