### PR TITLE
[FIX] pass kafka producer to rack middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.25.0
+* Fix pass kafka producer to rack middleware
+
 # 0.24.0
 * Fix Pass and use the span in annotate_plugin
 

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,3 +1,4 @@
+require 'finagle-thrift'
 require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -11,6 +11,11 @@ module ZipkinTracer
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'
           Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)
+        when :kafka_producer
+          require 'zipkin-tracer/zipkin_kafka_tracer'
+          options = { producer: config.kafka_producer }
+          options[:topic] = config.kafka_topic unless config.kafka_topic.nil?
+          Trace::ZipkinKafkaTracer.new(options)
         when :logger
           require 'zipkin-tracer/zipkin_logger_tracer'
           Trace::ZipkinLoggerTracer.new(logger: config.logger)
@@ -21,7 +26,7 @@ module ZipkinTracer
       Trace.tracer = tracer
 
       # TODO: move this to the TracerBase and kill scribe tracer
-      ip_format = config.adapter == :kafka ? :i32 : :string
+      ip_format = [:kafka, :kafka_producer].include?(config.adapter) ? :i32 : :string
       Trace.default_endpoint = Trace::Endpoint.local_endpoint(
         config.service_port,
         service_name(config.service_name),

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.24.0'.freeze
+  VERSION = '0.25.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -12,7 +12,7 @@ module Trace
   # This class sends information to Zipkin through Kafka.
   # Spans are encoded using Thrift
   class ZipkinKafkaTracer < ZipkinTracerBase
-    DEFAULT_KAFKA_TOPIC = "zipkin_kafka".freeze
+    DEFAULT_KAFKA_TOPIC = "zipkin".freeze
 
     def initialize(options = {})
       @topic  = options[:topic] || DEFAULT_KAFKA_TOPIC
@@ -26,6 +26,7 @@ module Trace
       end
       super(options)
     end
+    
     def flush!
       resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
       resolved_spans.each do |span|
@@ -33,7 +34,6 @@ module Trace
         trans = Thrift::MemoryBufferTransport.new(buf)
         oprot = Thrift::BinaryProtocol.new(trans)
         span.to_thrift.write(oprot)
-
         retval = @producer.push(buf, topic: @topic)
 
         # If @producer#push returns a promise/promise-like object, block until it

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -84,6 +84,12 @@ module ZipkinTracer
           config = Config.new(nil, zookeeper: 'http://server.yes.net')
           expect(config.adapter).to eq(:kafka)
         end
+
+        it 'returns :kafka_producer if producer is set' do
+          producer = double("Producer", push: true)
+          config = Config.new(nil, producer: producer)
+          expect(config.adapter).to eq(:kafka_producer)
+        end
       end
     end
   end


### PR DESCRIPTION
`:producer` was ignored by the Config and TracerFactory 