### PR TITLE
fix memory leak when doing faraday request in a new thread

### DIFF
--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -89,6 +89,10 @@ module Trace
       record_tag(BinaryAnnotation::LOCAL_COMPONENT, value)
     end
 
+    def has_parent_span?
+      !@span_id.parent_id.nil?
+    end
+
     private
 
     UNKNOWN_DURATION = 0 # mark duration was not set

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -23,7 +23,16 @@ module Trace
 
     def end_span(span)
       span.close
-      if span.annotations.any?{ |ann| ann.value == Annotation::SERVER_SEND }
+      # if in a thread not handling incoming http requests, it will not have Annotation::SERVER_SEND, so the span
+      # will never be flushed and will cause memory leak.
+      # It will have CLIENT_SEND and CLIENT_RECV if the thread sends out http requests, so use CLIENT_RECV as the sign
+      # to flush the span.
+      has_server_recv_span = spans.any? do |s|
+        s.annotations.any? { |ann| ann.value == Annotation::SERVER_RECV }
+      end
+      if span.annotations.any? { |ann| ann.value == Annotation::SERVER_SEND } ||
+          (!has_server_recv_span &&
+              span.annotations.any? { |ann| ann.value == Annotation::CLIENT_RECV })
         flush!
         reset
       end

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -23,16 +23,12 @@ module Trace
 
     def end_span(span)
       span.close
-      # if in a thread not handling incoming http requests, it will not have Annotation::SERVER_SEND, so the span
+      # If in a thread not handling incoming http requests, it will not have Annotation::SERVER_SEND, so the span
       # will never be flushed and will cause memory leak.
       # It will have CLIENT_SEND and CLIENT_RECV if the thread sends out http requests, so use CLIENT_RECV as the sign
       # to flush the span.
-      has_server_recv_span = spans.any? do |s|
-        s.annotations.any? { |ann| ann.value == Annotation::SERVER_RECV }
-      end
-      if span.annotations.any? { |ann| ann.value == Annotation::SERVER_SEND } ||
-          (!has_server_recv_span &&
-              span.annotations.any? { |ann| ann.value == Annotation::CLIENT_RECV })
+      # If no parent span, then current span needs to flush when it ends.
+      if !span.has_parent_span? || span.annotations.any? { |ann| ann.value == Annotation::SERVER_SEND }
         flush!
         reset
       end


### PR DESCRIPTION
A second thought is: if this thread has multiple async http requests, "detect this previous span" logic will break and it will become a mess.
So I submit another solution: detect whether a span has parent, if not, then it needs to be flush immediately. And because of the logic, I have to change some unit tests. But I believe the old application users will not be affected by this logic.

@jfeltesse-mdsol @jcarres-mdsol 