### PR TITLE
Adds tagging of errors to spans which failed status codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
+  - 2.1.10
   - 2.0
   - jruby-9.1.6.0
 deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.27.0
+* Add tagging of errors for Faraday and Excon.
+
 # 0.26.0
 * Add sidekiq worker tracing.
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -120,6 +120,7 @@ module Trace
     PATH = 'http.path'.freeze
     STATUS = 'http.status'.freeze
     LOCAL_COMPONENT = 'lc'.freeze
+    ERROR = 'error'.freeze
 
     def to_h
       {

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.26.0'.freeze
+  VERSION = '0.27.0'.freeze
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -5,7 +5,7 @@ require 'lib/middleware_shared_examples'
 describe ZipkinTracer::ExconHandler do
   # returns the request headers
   def process(body, url, headers = {})
-    stub_request(:post, url).to_return(status: 200, body: body, headers: headers)
+    stub_request(:post, url).to_return(status: 404, body: body, headers: headers)
 
     connection = Excon.new(url.to_s,
                            body: body,

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -18,7 +18,7 @@ describe ZipkinTracer::FaradayHandler do
     end
   end
 
-  let(:response_env) { { status: 200 } }
+  let(:response_env) { { status: 404 } }
   let(:wrapped_app) { lambda { |env| ResponseObject.new(env, response_env) } }
 
   # returns the request headers

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -66,7 +66,13 @@ shared_examples 'make requests' do |expect_to_trace_request|
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
       expect(key).to eq('http.status')
-      expect(value).to eq('200')
+      expect(value).to eq('404')
+      expect_host(host, '127.0.0.1', service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+      expect(key).to eq('error')
+      expect(value).to eq('404')
       expect_host(host, '127.0.0.1', service_name)
     end
 


### PR DESCRIPTION

See this for background https://github.com/openzipkin/zipkin/pull/1675

@adriancole  maybe other PR provides a better background?
@jfeltesse-mdsol  @ykitamura-mdsol  please review.

I understand there is duplication of code between Faraday and Excon, not only this new tag, others are duplicating also, to be fixed in some other PR.

