### PR TITLE
Add basic authentication support for json tracer

### DIFF
--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -6,9 +6,9 @@ module ZipkinTracer
   # Configuration of this gem. It reads the configuration and provides default values
   class Config
     attr_reader :service_name, :service_port, :json_api_host,
-      :zookeeper, :sample_rate, :logger, :log_tracing,
-      :annotate_plugin, :filter_plugin, :whitelist_plugin,
-      :sampled_as_boolean, :record_on_server_receive,
+      :json_api_user, :json_api_password, :zookeeper, :sample_rate,
+      :logger, :log_tracing, :annotate_plugin, :filter_plugin,
+      :whitelist_plugin, :sampled_as_boolean, :record_on_server_receive,
       :kafka_producer, :kafka_topic
 
     def initialize(app, config_hash)
@@ -19,6 +19,12 @@ module ZipkinTracer
       @service_port      = config[:service_port]      || DEFAULTS[:service_port]
       # The address of the Zipkin server which we will send traces to
       @json_api_host     = config[:json_api_host]
+      # The username for basic authentication
+      @json_api_user     = config[:json_api_user]
+      # The password for basic authentication
+      @json_api_password = config[:json_api_password]
+      # SSL verify
+      @json_api_ssl_verify = config[:json_api_ssl_verify]
       # Zookeeper information
       @zookeeper         = config[:zookeeper]
       # Kafka producer information

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -7,6 +7,8 @@ module ZipkinTracer
         when :json
           require 'zipkin-tracer/zipkin_json_tracer'
           options = { json_api_host: config.json_api_host, logger: config.logger }
+          options[:json_api_user] = config.json_api_user unless config.json_api_user.nil?
+          options[:json_api_password] = config.json_api_password unless config.json_api_password.nil?
           Trace::ZipkinJsonTracer.new(options)
         when :kafka
           require 'zipkin-tracer/zipkin_kafka_tracer'


### PR DESCRIPTION
This pull request will add basic authentication support to the json tracer so you are still able to use zipkin when the server is protected with basic auth.