### PR TITLE
Rescue connection errors when sending information to Zipkin fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.27.1
+* Rescue connection errors when sending information to Zipkin fails
+
 # 0.27.0
 * Add tagging of errors for Faraday and Excon.
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.27.0'.freeze
+  VERSION = '0.27.1'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -14,6 +14,10 @@ class AsyncJsonApiClient
       req.headers['Content-Type'] = 'application/json'
       req.body = JSON.generate(spans_with_ips)
     end
+  rescue Net::ReadTimeout, Faraday::ConnectionFailed => e
+    error_message = "Got #{e.class.inspect} with Message #{e.message} error while connecting to #{json_api_host}. " \
+                    "- Please make sure the Zipkin server is running in that url and port."
+    SuckerPunch.logger.error(error_message)
   rescue => e
     SuckerPunch.logger.error(e)
   end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -15,8 +15,8 @@ class AsyncJsonApiClient
       req.body = JSON.generate(spans_with_ips)
     end
   rescue Net::ReadTimeout, Faraday::ConnectionFailed => e
-    error_message = "Got #{e.class.inspect} with Message #{e.message} error while connecting to #{json_api_host}. " \
-                    "- Please make sure the Zipkin server is running in that url and port."
+    error_message = "Error while connecting to #{json_api_host}: #{e.class.inspect} with message '#{e.message}'. " \
+                    "Please make sure the URL / port are properly specified for the Zipkin server."
     SuckerPunch.logger.error(error_message)
   rescue => e
     SuckerPunch.logger.error(e)


### PR DESCRIPTION
Rescue the following errors in `AsyncJsonApiClient#perform` method to make the error message more helpful:

- Net::ReadTimeout
- Faraday::ConnectionFailed

<img width="1007" alt="screen shot 2017-11-14 at 3 04 45 pm" src="https://user-images.githubusercontent.com/16286071/32765330-3c2ad2c6-c94d-11e7-8ec3-b489734d1667.png">

@adriancole @jcarres-mdsol  @jfeltesse-mdsol

