### PR TITLE
Stringify trace values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.27.2
+* Convert trace values to string
+* Add logging on 400 Bad Request
+
 # 0.27.1
 * Rescue connection errors when sending information to Zipkin fails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 0.27.2
 * Convert trace values to string
-* Add logging on 400 Bad Request
 
 # 0.27.1
 * Rescue connection errors when sending information to Zipkin fails

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -78,11 +78,11 @@ module Trace
 
     # We record information into spans, then we send these spans to zipkin
     def record(value, endpoint = Trace.default_endpoint)
-      annotations << Trace::Annotation.new(value, endpoint)
+      annotations << Trace::Annotation.new(value.to_s, endpoint)
     end
 
     def record_tag(key, value, type = Trace::BinaryAnnotation::Type::STRING, endpoint = Trace.default_endpoint)
-      binary_annotations << Trace::BinaryAnnotation.new(key, value, type, endpoint)
+      binary_annotations << Trace::BinaryAnnotation.new(key, value.to_s, type, endpoint)
     end
 
     def record_local_component(value)

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.27.1'.freeze
+  VERSION = '0.27.2'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -6,7 +6,6 @@ require 'zipkin-tracer/hostname_resolver'
 class AsyncJsonApiClient
   include SuckerPunch::Job
   SPANS_PATH = '/api/v1/spans'
-  BAD_REQUEST = 400
 
   def perform(json_api_host, spans)
     spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
@@ -15,7 +14,6 @@ class AsyncJsonApiClient
       req.headers['Content-Type'] = 'application/json'
       req.body = JSON.generate(spans_with_ips)
     end
-    SuckerPunch.logger.error(resp.body) if resp.status == BAD_REQUEST
   rescue Net::ReadTimeout, Faraday::ConnectionFailed => e
     error_message = "Error while connecting to #{json_api_host}: #{e.class.inspect} with message '#{e.message}'. " \
                     "Please make sure the URL / port are properly specified for the Zipkin server."

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -69,6 +69,7 @@ describe Trace do
     let(:duration) { 0 }
     let(:key) { 'key' }
     let(:value) { 'value' }
+    let(:numeric_value) { 123 }
 
     before do
       Timecop.freeze(Time.utc(2016, 1, 16, 23, 45))
@@ -102,6 +103,13 @@ describe Trace do
         ann = span_with_parent.annotations[-1]
         expect(ann.value).to eq('value')
       end
+
+      it 'converts the value to string' do
+        span_with_parent.record(numeric_value)
+
+        ann = span_with_parent.annotations[-1]
+        expect(ann.value).to eq('123')
+      end
     end
 
     describe '#record_tag' do
@@ -111,6 +119,13 @@ describe Trace do
         ann = span_with_parent.binary_annotations[-1]
         expect(ann.key).to eq('key')
         expect(ann.value).to eq('value')
+      end
+
+      it 'converts the value to string' do
+        span_with_parent.record_tag(key, numeric_value)
+
+        ann = span_with_parent.binary_annotations[-1]
+        expect(ann.value).to eq('123')
       end
     end
 


### PR DESCRIPTION
## Background
Sending numeric trace values causes errors in Zipkin but the errors are not logged:
```ruby
span.record_tag 'id', 123
```

## Update summary
- Converting trace values to string in `Trace::Span#record` and `Trace::Span#record_tag` methods.
- ~~Add logging when Zipkin returns 400 Bad Request to catch `Cannot decode spans due to IllegalArgumentException` errors~~

@adriancole @jcarres-mdsol  @jfeltesse-mdsol @ssteeg-mdsol 