### PR TITLE
Update version.rb to fix checksum mismatch and add 'condition' on Travis CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
+    condition: "$TRAVIS_RUBY_VERSION == 2.4.1"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.27.2.1
+* Update version.rb to fix checksum mismatch on RubyGems.org
+
 # 0.27.2
 * Convert trace values to string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.27.2.1
 * Update version.rb to fix checksum mismatch on RubyGems.org
+* Add `condition` on Travis CI deployment
 
 # 0.27.2
 * Convert trace values to string

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.27.2'.freeze
+  VERSION = '0.27.2.1'.freeze
 end


### PR DESCRIPTION
Got a checksum mismatch on RubyGems.org with version `0.27.2`:

```
Bundler cannot continue installing zipkin-tracer (0.27.2).
The checksum for the downloaded `zipkin-tracer-0.27.2.gem` does not match the
checksum given by the server. 

(More info: The expected SHA256 checksum was
"6698c19b0cec9ee42cb413748398a3c92b3a267c28d694e98e84dcc696fb454a", but the
checksum for the downloaded gem was
"d3b4879bf0e8a535bbfbeda4e7cb67735084dc044db6b609dd56be70ae593328".)
```

Updating the version from `0.27.2` to `0.27.2.1` to fix the issue.

@adriancole @jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol