### PR TITLE
Support 128-bit trace IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
   - 2.1.10
   - 2.0
   - jruby-9.1.6.0
@@ -16,7 +17,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
-    condition: "$TRAVIS_RUBY_VERSION == 2.4.1"
+    condition: "$TRAVIS_RUBY_VERSION == 2.5.1"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.28.0
+* Add the `:trace_id_128bit` configuration option.
+
 # 0.27.2.1
 * Update version.rb to fix checksum mismatch on RubyGems.org
 * Add `condition` on Travis CI deployment

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
 * `:record_on_server_receive` - a CSV style list of tags to record on server receive, even if the zipkin headers were present in the incoming request. Currently only supports the value `http.path`, others being discarded.
+* `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
 
 ### Sending traces on outgoing requests with Faraday
 

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -34,7 +34,8 @@ module ZipkinTracer
         trace_id, span_id = @env.values_at(*B3_REQUIRED_HEADERS)
         parent_span_id = @env['HTTP_X_B3_PARENTSPANID']
       else
-        trace_id = span_id = Trace.generate_id
+        span_id = Trace.generate_id
+        trace_id = TraceGenerator.new.generate_id_from_span_id(span_id)
         parent_span_id = nil
       end
       [trace_id, span_id, parent_span_id]

--- a/lib/zipkin-tracer/trace_generator.rb
+++ b/lib/zipkin-tracer/trace_generator.rb
@@ -12,11 +12,15 @@ module ZipkinTracer
 
     def generate_trace_id
       span_id = generate_id
-      Trace::TraceId.new(span_id, nil, span_id, should_sample?.to_s, Trace::Flags::EMPTY)
+      Trace::TraceId.new(generate_id_from_span_id(span_id), nil, span_id, should_sample?.to_s, Trace::Flags::EMPTY)
     end
 
     def should_sample?
       rand < (Trace.sample_rate || DEFAULT_SAMPLE_RATE)
+    end
+
+    def generate_id_from_span_id(span_id)
+      Trace.trace_id_128bit ? generate_id_128bit(span_id) : span_id
     end
 
     private
@@ -25,7 +29,21 @@ module ZipkinTracer
       rand(TRACE_ID_UPPER_BOUND)
     end
 
+    def generate_id_128bit(span_id)
+      trace_id_low_64bit = '%016x' % span_id
+      "#{trace_id_epoch_seconds}#{trace_id_high_32bit}#{trace_id_low_64bit}".hex
+    end
+
+    def trace_id_epoch_seconds
+      '%08x' % Time.now.to_i
+    end
+
+    def trace_id_high_32bit
+      '%08x' % rand(TRACE_ID_HIGH_32BIT_UPPER_BOUND)
+    end
+
     TRACE_ID_UPPER_BOUND = 2**64
+    TRACE_ID_HIGH_32BIT_UPPER_BOUND = 2**32
     DEFAULT_SAMPLE_RATE = 0.001
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.27.2.1'.freeze
+  VERSION = '0.28.0'.freeze
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -21,7 +21,7 @@ module ZipkinTracer
 
     it 'sets defaults' do
       config = Config.new(nil, {})
-      [:sample_rate, :service_port, :sampled_as_boolean].each do |key|
+      [:sample_rate, :service_port, :sampled_as_boolean, :trace_id_128bit].each do |key|
         expect(config.send(key)).to_not eq(nil)
       end
     end

--- a/spec/lib/rack/zipkin_env_spec.rb
+++ b/spec/lib/rack/zipkin_env_spec.rb
@@ -82,6 +82,16 @@ describe ZipkinTracer::ZipkinEnv do
       # In this spec we are forcing sampling with the whitelist_plugin
       expect(zipkin_env.trace_id.sampled?).to eq(true)
     end
+
+    context 'trace_id_128bit is true' do
+      before do
+        allow(Trace).to receive(:trace_id_128bit).and_return(true)
+      end
+
+      it 'generates a 128-bit trace_id' do
+        expect(zipkin_env.trace_id.trace_id.to_s).to match(/^[a-f0-9]{32}$/i)
+      end
+    end
   end
 
   context 'with zipkin headers' do


### PR DESCRIPTION
Add the `:trace_id_128bit` configuration option to support 128-bit trace IDs

https://github.com/openzipkin/b3-propagation/issues/6

@adriancole @jcarres-mdsol @ssteeg-mdsol @cabbott