### PR TITLE
Create a cleaner temporary request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.29.1
+* Patch abstract route to work with Grape
+
 # 0.29.0
 * Add abstract route to span name
 * Fix not to raise "NoMethodError" for Rails:Module

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -13,7 +13,7 @@ module ZipkinTracer
 
     def self.get_route(env)
       return nil unless defined?(Rails)
-      req = Rack::Request.new(env)
+      req = Rack::Request.new("PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO], "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD])
       # Returns a string like /some/path/:id
       Rails.application.routes.router.recognize(req) do |route|
         return route.path.spec.to_s

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -13,7 +13,11 @@ module ZipkinTracer
 
     def self.get_route(env)
       return nil unless defined?(Rails)
-      req = Rack::Request.new("PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO], "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD])
+      stub_env = {
+        "PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO],
+        "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD]
+      }
+      req = Rack::Request.new(stub_env)
       # Returns a string like /some/path/:id
       Rails.application.routes.router.recognize(req) do |route|
         return route.path.spec.to_s

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.29.0'.freeze
+  VERSION = '0.29.1'.freeze
 end


### PR DESCRIPTION
Using `Rails.application.routes.router.recognize` is not safe as it updates the passed argument, which is request in our case. Specifically it updates `rails_req.script_name` from `""` to `"/"` which makes `request.path` to have double slash in the beginning. To solve this issue it has been created a temporary clean request object which will be disposed later.

See also: https://github.com/openzipkin/zipkin-ruby/pull/122/files (PR that has the same line before).