### PR TITLE
Add http.method to client annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - 2.2.10
   - 2.1.10
   - 2.0
@@ -17,7 +17,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
-    condition: "$TRAVIS_RUBY_VERSION == 2.5.1"
+    condition: "$TRAVIS_RUBY_VERSION == 2.5.3"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.30.0
+* Add 'http.method' to client annotations
+
 # 0.29.1
 * Patch abstract route to work with Grape
 

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -80,12 +80,14 @@ module ZipkinTracer
     end
 
     def trace!(datum, trace_id)
+      method = datum[:method].to_s
       url_string = Excon::Utils::request_uri(datum)
       url = URI(url_string)
       service_name = service_name(datum, url.host)
 
-      span = Trace.tracer.start_span(trace_id, datum[:method].to_s.downcase)
+      span = Trace.tracer.start_span(trace_id, method.downcase)
       # annotate with method (GET/POST/etc.) and uri path
+      span.record_tag(Trace::BinaryAnnotation::METHOD, method.upcase, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
       span.record_tag(Trace::BinaryAnnotation::PATH, url.path, Trace::BinaryAnnotation::Type::STRING, local_endpoint)
       span.record_tag(Trace::BinaryAnnotation::SERVER_ADDRESS, SERVER_ADDRESS_SPECIAL_VALUE, Trace::BinaryAnnotation::Type::BOOL, remote_endpoint(url, service_name))
       span.record(Trace::Annotation::CLIENT_SEND, local_endpoint)

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -151,6 +151,7 @@ module Trace
   class BinaryAnnotation
     SERVER_ADDRESS = 'sa'.freeze
     URI = 'http.uri'.freeze
+    METHOD = 'http.method'.freeze
     PATH = 'http.path'.freeze
     STATUS = 'http.status'.freeze
     LOCAL_COMPONENT = 'lc'.freeze

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.29.1'.freeze
+  VERSION = '0.30.0'.freeze
 end

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -52,6 +52,12 @@ shared_examples 'make requests' do |expect_to_trace_request|
     expect(tracer).to receive(:end_span).with(anything).and_call_original
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+      expect(key).to eq('http.method')
+      expect(value).to eq('POST')
+      expect_host(host, '127.0.0.1', service_name)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
       expect(key).to eq('http.path')
       expect(value).to eq(url_path)
       expect_host(host, '127.0.0.1', service_name)


### PR DESCRIPTION
Since abstract route is added to span names in https://github.com/openzipkin/zipkin-ruby/pull/122, adding the [`HTTP method`](https://zipkin.io/public/thrift/v1/zipkinCore.html#Const_HTTP_METHOD) to client annotations.

@adriancole @jcarres-mdsol 