### PR TITLE
Removes dependency on finagle and thrift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
+  - 2.6.0
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - 2.2.10
-  - 2.1.10
-  - 2.0
   - jruby-9.1.6.0
 deploy:
   provider: rubygems
@@ -17,7 +15,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
-    condition: "$TRAVIS_RUBY_VERSION == 2.5.3"
+    condition: "$TRAVIS_RUBY_VERSION == 2.6.0"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.31.0
+* Remove dependency from finagle-thrift
+
 # 0.30.0
 * Add 'http.method' to client annotations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.31.0
 * Remove dependency from finagle-thrift
+* Use http.url instead of http.uri
 
 # 0.30.0
 * Add 'http.method' to client annotations

--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,3 @@ platform :jruby do
   gem 'hermann', '~> 0.27.0'
 end
 
-platform :ruby_20 do
-  gem 'rack', '~> 1.0'
-end
-
-platform :ruby_21 do
-  gem 'rack', '~> 1.0'
-end

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ responds to #value!, it will be called (to block until completed).
 
 Caveat: Hermann is only usable from within Jruby, due to its implementation of zookeeper based broker discovery being JVM based.
 
+The Kafka transport send data using Thrift. Since version 0.31.0, Thrift is not a dependency, thus the gem 'finagle-thrift' needs to be added to the Gemfile also.
+
 ### Logger
 
 The simplest tracer that does something. It will log all your spans.

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ lambda do |span, env, status, response_headers, response_body|
   # string annotation
   span.record_tag('http.referrer', env['HTTP_REFERRER'])
   # integer annotation
-  span.record_tag('http.content_size', [env['CONTENT_SIZE']].pack('N'), Trace::BinaryAnnotation::Type::I32, ep)
-  span.record_tag('http.status', [status.to_i].pack('n'), Trace::BinaryAnnotation::Type::I16, ep)
+  span.record_tag('http.content_size', env['CONTENT_SIZE'].to_s)
+  span.record_tag('http.status', status)
 end
 ```
 

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,5 +1,3 @@
-require 'finagle-thrift'
-require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
 require 'zipkin-tracer/sidekiq/middleware'

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -1,5 +1,3 @@
-require 'finagle-thrift/trace'
-require 'finagle-thrift/tracer'
 require 'uri'
 require 'excon'
 

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -1,6 +1,4 @@
 require 'faraday'
-require 'finagle-thrift/trace'
-require 'finagle-thrift/tracer'
 require 'uri'
 
 module ZipkinTracer

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -1,6 +1,4 @@
 require 'rack'
-require 'finagle-thrift/trace'
-require 'finagle-thrift/tracer'
 require 'zipkin-tracer/config'
 require 'zipkin-tracer/tracer_factory'
 require 'zipkin-tracer/rack/zipkin_env'

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -34,7 +34,7 @@ module ZipkinTracer
         trace_id, span_id = @env.values_at(*B3_REQUIRED_HEADERS)
         parent_span_id = @env['HTTP_X_B3_PARENTSPANID']
       else
-        span_id = Trace.generate_id
+        span_id = TraceGenerator.new.generate_id
         trace_id = TraceGenerator.new.generate_id_from_span_id(span_id)
         parent_span_id = nil
       end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -1,6 +1,7 @@
 require 'zipkin-tracer/zipkin_tracer_base'
-# Module with a mix of functions and overwrites from the finagle implementation:
+# Most of this code is copied from Finagle
 # https://github.com/twitter/finagle/blob/finagle-6.39.0/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb
+# But moved and improved here.
 module Trace
   # These methods and attr_accessor below are used as global configuration of this gem
   # Most of these are set by the config class and then used around.
@@ -62,7 +63,7 @@ module Trace
 
   class BinaryAnnotation
     SERVER_ADDRESS = 'sa'.freeze
-    URI = 'http.uri'.freeze
+    URI = 'http.url'.freeze
     METHOD = 'http.method'.freeze
     PATH = 'http.path'.freeze
     STATUS = 'http.status'.freeze
@@ -128,7 +129,6 @@ module Trace
   end
 
   # A TraceId contains all the information of a given trace id
-  # This class is defined in finagle-thrift. We are overwriting it here
   class TraceId
     attr_reader :trace_id, :parent_id, :span_id, :sampled, :flags
 
@@ -158,8 +158,6 @@ module Trace
     end
   end
 
-  # This class is the 128-bit version of the SpanId class:
-  # https://github.com/twitter/finagle/blob/finagle-6.39.0/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb#L102
   class TraceId128Bit < SpanId
     HEX_REGEX_16 = /^[a-f0-9]{16}$/i
     HEX_REGEX_32 = /^[a-f0-9]{32}$/i

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -71,11 +71,6 @@ module Trace
 
     module Type
       BOOL = "BOOL"
-      BYTES = "BYTES"
-      I16 = "I16"
-      I32 = "I32"
-      I64 = "I64"
-      DOUBLE = "DOUBLE"
       STRING = "STRING"
     end
     attr_reader :key, :value, :host

--- a/lib/zipkin-tracer/trace_generator.rb
+++ b/lib/zipkin-tracer/trace_generator.rb
@@ -4,7 +4,7 @@ module ZipkinTracer
     # Next id, based on the current information in the container
     def next_trace_id
       if TraceContainer.tracing_information_set?
-        TraceContainer.current.next_id
+        TraceContainer.current.next_id(generate_id)
       else
         generate_trace_id
       end
@@ -23,11 +23,11 @@ module ZipkinTracer
       Trace.trace_id_128bit ? generate_id_128bit(span_id) : span_id
     end
 
-    private
-
     def generate_id
       rand(TRACE_ID_UPPER_BOUND)
     end
+
+    private
 
     def generate_id_128bit(span_id)
       trace_id_low_64bit = '%016x' % span_id

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -2,6 +2,7 @@
 begin
   require 'hermann/producer'
   require 'hermann/discovery/zookeeper'
+  require 'finagle-thrift'
 rescue LoadError => e
 end
 
@@ -26,7 +27,7 @@ module Trace
       end
       super(options)
     end
-    
+
     def flush!
       resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
       resolved_spans.each do |span|

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'finagle-thrift/tracer'
 
 module Trace
   # This class is a base for tracers sending information to Zipkin.
@@ -7,7 +6,7 @@ module Trace
   # is done with its request
   # Traces dealing with zipkin should inherit from this class and implement the
   # flush! method which actually sends the information
-  class ZipkinTracerBase < Tracer
+  class ZipkinTracerBase
 
     def initialize(options={})
       @options = options

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -177,7 +177,7 @@ describe ZipkinTracer::RackHandler do
         # string annotation
         span.record_tag('foo', env['foo'] || 'FOO')
         # integer annotation
-        span.record_tag('http.status', [status.to_i].pack('n'), Trace::BinaryAnnotation::Type::I16, ::Trace.default_endpoint)
+        span.record_tag('http.status', status)
       end
     end
     subject { middleware(app, annotate_plugin: annotate) }

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -236,7 +236,7 @@ describe Trace do
     describe '.local_endpoint' do
       it 'auto detects the hostname' do
         allow(Socket).to receive(:gethostname).and_return('z1.example.com')
-        expect(Trace::Endpoint).to receive(:make_endpoint).with('z1.example.com', 80, service_name, :string)
+        expect(Trace::Endpoint).to receive(:new).with('z1.example.com', 80, service_name, :string)
         Trace::Endpoint.local_endpoint(80, service_name, :string)
       end
     end
@@ -253,7 +253,7 @@ describe Trace do
         end
 
         it 'does not translate the hostname' do
-          ep = ::Trace::Endpoint.make_endpoint(hostname, 80, service_name, :string)
+          ep = ::Trace::Endpoint.new(hostname, 80, service_name, :string)
           expect(ep.ipv4).to eq(hostname)
           expect(ep.ip_format).to eq(:string)
         end

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 require 'zipkin-tracer/zipkin_logger_tracer'
 
 describe Trace::ZipkinLoggerTracer do
-  let(:span_id) { Trace.generate_id }
+  let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
   let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
   let(:name) { 'trusmis' }
   let(:logger) { Logger.new(nil) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 if ENV['COV']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
 end
 
 require 'zipkin-tracer'
@@ -10,6 +12,7 @@ require 'sucker_punch/testing/inline'
 
 RSpec.configure do |config|
   config.order = :random
+  RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
   config.after(:each) do
     Timecop.return

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -28,10 +28,10 @@ class TestApp
 
   def store_current_trace_info
     current_trace_info = {
-      'trace_id'        => ::Trace.id.trace_id.to_s,
-      'parent_span_id'  => ::Trace.id.parent_id.to_s,
-      'span_id'         => ::Trace.id.span_id.to_s,
-      'sampled'         => ::Trace.id.sampled.to_s
+      'trace_id'        => ZipkinTracer::TraceContainer.current.trace_id.to_s,
+      'parent_span_id'  => ZipkinTracer::TraceContainer.current.parent_id.to_s,
+      'span_id'         => ZipkinTracer::TraceContainer.current.span_id.to_s,
+      'sampled'         => ZipkinTracer::TraceContainer.current.sampled.to_s
     }
     self.class.add_trace(current_trace_info.to_json)
   end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |s|
   s.require_path              = 'lib'
 
   s.add_dependency 'faraday', '~> 0.8'
-  s.add_dependency 'finagle-thrift', '~> 1.4.2'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 
   s.add_development_dependency 'excon', '~> 0.53'
-  s.add_development_dependency 'rspec', '~> 3.3'
-  s.add_development_dependency 'rack-test', '~> 0.6'
+  s.add_development_dependency 'rspec', '~> 3.8'
+  s.add_development_dependency 'rack-test', '~> 1.1'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop', '~> 0.8'
   s.add_development_dependency 'webmock', '~> 3.0'
+  s.add_development_dependency 'simplecov', '~> 0.16'
 end


### PR DESCRIPTION

@jfeltesse-mdsol @ykitamura-mdsol @ssteeg-mdsol @adriancole 

I do not know what else is in finagle but it is huge. Removing finagle from a rails project lowered the startup memory from 78MB to 74MB
That's 4 times the memory taken by the mysql adaptor for instance.

Anyways, another good reason is that we were in effect monkey patching a lot of classes. Now we got them complete in this codebase and we can move them out of the terrible high level Trace module in a different PR as well as doing some other cleanups. I did not do that on this PR as it is big enough.

Most code changes is moving finagle code into this codebase.

Specs changes are mostly because we were not spec-ing the right thing. We were testing and modifying Trace.id instead of TraceContainer.current, the thing was working by some miracle.


