### PR TITLE
Fix randomly failing spec

### DIFF
--- a/spec/lib/trace_generator_spec.rb
+++ b/spec/lib/trace_generator_spec.rb
@@ -61,13 +61,14 @@ describe ZipkinTracer::TraceGenerator do
     context 'trace_id_128bit is true' do
       let(:trace_id_128bit) { true }
       let(:generated_id) { subject.generate_id_from_span_id(span_id) }
+      let(:trace_id_low_64bit) { '%016x' % span_id }
 
       before do
         Timecop.freeze(Time.utc(2018, 5, 9, 14, 32))
       end
 
       it 'prepends high 8-bytes(4-bytes epoch seconds and 4-bytes random) to the span_id' do
-        expect(generated_id.to_s(16)).to match(/^5af30660[a-f0-9]{8}#{span_id.to_s(16)}$/)
+        expect(generated_id.to_s(16)).to match(/^5af30660[a-f0-9]{8}#{trace_id_low_64bit}$/)
       end
     end
   end


### PR DESCRIPTION
Fix not to raise the following error when span_id is starting from `0`:

```
  1) ZipkinTracer::TraceGenerator#generate_id_from_span_id trace_id_128bit is true prepends high 8-bytes(4-bytes epoch seconds and 4-bytes random) to the span_id
     Failure/Error: expect(generated_id.to_s(16)).to match(/^5af30660[a-f0-9]{8}#{span_id.to_s(16)}$/)
     
       expected "5af3066036f721b20fea18527cdba912" to match /^5af30660[a-f0-9]{8}fea18527cdba912$/
       Diff:
       @@ -1,2 +1,2 @@
       -/^5af30660[a-f0-9]{8}fea18527cdba912$/
       +"5af3066036f721b20fea18527cdba912"
       
     # ./spec/lib/trace_generator_spec.rb:70:in `block (4 levels) in <top (required)>'
```

span_id.to_s(16) => `fea18527cdba912`
'%016x' % span_id => `0fea18527cdba912`

@jcarres-mdsol This is why [your CI build failed](https://circleci.com/gh/openzipkin/zipkin-ruby/24?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). Sorry! 🙇 