### PR TITLE
Fixes JSON v1 encoding of remote address binary annotations

### DIFF
--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -94,7 +94,8 @@ module Trace
     def to_h
       {
         key: @key,
-        value: @value,
+        # special case address binary annotations which use BOOL type
+        value: @annotation_type == Trace::BinaryAnnotation::Type::BOOL ? true : @value,
         endpoint: host.to_h
       }
     end

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -231,6 +231,16 @@ describe Trace do
           endpoint: dummy_endpoint.to_h
         )
       end
+
+      it 'returns a hash representation of an address binary annotation' do
+        addr = Trace::BinaryAnnotation.new('sa', 1, 'BOOL', dummy_endpoint)
+
+        expect(addr.to_h).to eq(
+          key: 'sa',
+          value: true,
+          endpoint: dummy_endpoint.to_h
+        )
+      end
     end
   end
 


### PR DESCRIPTION
The only use case for BOOL binary annotations is identifying the remote
endpoint. In thrift encoding, BOOL true is represented by 1. This
accidentally carried into JSON encoding, which tripped up endpoint
interpretation. This fixes it by special casing BOOL.

See https://github.com/openzipkin/zipkin/issues/2414