### PR TITLE
Switch to Zipkin v2 span format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.33.0
+* Switch to Zipkin v2 span format
+
 # 0.32.4
 * Remove the ':service_port' configuration.
 * Fix 'sa' annotation encoding.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ lambda do |span, env, status, response_headers, response_body|
   span.record_tag('http.referrer', env['HTTP_REFERRER'])
   # integer annotation
   span.record_tag('http.content_size', env['CONTENT_SIZE'].to_s)
-  span.record_tag('http.status', status)
+  span.record_tag('http.status_code', status)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It can be used to measure the performance of process, record value of variables,
 
 When `local_component_span` method is called, it creates a new span and a local component, and provides the following methods to create annotations.
 * record(key) - annotation
-* record_tag(key, value) - binary annotation
+* record_tag(key, value) - tag
 
 Example:
 ```ruby
@@ -105,7 +105,7 @@ Only one of the following tracers can be used at a given time.
 
 Sends traces as JSON over HTTP. This is the preferred tracer to use as the openzipkin project moves away from Thrift.
 
-You need to specify the `:json_api_host` parameter to wherever your zipkin collector is running. It will POST traces to the `/api/v1/spans` path.
+You need to specify the `:json_api_host` parameter to wherever your zipkin collector is running. It will POST traces to the `/api/v2/spans` path.
 
 
 ### Kafka

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -12,7 +12,7 @@ module ZipkinTracer
     REQUEST_METHOD = Rack::REQUEST_METHOD rescue 'REQUEST_METHOD'.freeze
 
     DEFAULT_SERVER_RECV_TAGS = {
-     Trace::BinaryAnnotation::PATH => PATH_INFO
+     Trace::Span::Tag::PATH => PATH_INFO
     }.freeze
 
     def initialize(app, config = nil)
@@ -55,12 +55,11 @@ module ZipkinTracer
 
     def trace!(span, zipkin_env, &block)
       trace_request_information(span, zipkin_env)
-      span.record(Trace::Annotation::SERVER_RECV)
+      span.kind = Trace::Span::Kind::SERVER
       span.record('whitelisted') if zipkin_env.force_sample?
       status, headers, body = yield
     ensure
       annotate_plugin(span, zipkin_env.env, status, headers, body)
-      span.record(Trace::Annotation::SERVER_SEND)
     end
 
     def trace_request_information(span, zipkin_env)

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -165,7 +165,7 @@ module Trace
     module Tag
       METHOD = "http.method".freeze
       PATH = "http.path".freeze
-      STATUS = "http.status".freeze
+      STATUS = "http.status_code".freeze
       LOCAL_COMPONENT = "lc".freeze
       ERROR = "error".freeze
     end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -49,7 +49,7 @@ module Trace
 
   class Annotation
     attr_reader :value, :timestamp
-    
+
     def initialize(value)
       @timestamp = (Time.now.to_f * 1000 * 1000).to_i # micros
       @value = value
@@ -101,14 +101,15 @@ module Trace
 
   # A TraceId contains all the information of a given trace id
   class TraceId
-    attr_reader :trace_id, :parent_id, :span_id, :sampled, :flags
+    attr_reader :trace_id, :parent_id, :span_id, :sampled, :flags, :shared
 
-    def initialize(trace_id, parent_id, span_id, sampled, flags)
+    def initialize(trace_id, parent_id, span_id, sampled, flags, shared = false)
       @trace_id = Trace.trace_id_128bit ? TraceId128Bit.from_value(trace_id) : SpanId.from_value(trace_id)
       @parent_id = parent_id.nil? ? nil : SpanId.from_value(parent_id)
       @span_id = SpanId.from_value(span_id)
       @sampled = sampled
       @flags = flags
+      @shared = shared
     end
 
     def next_id
@@ -125,7 +126,8 @@ module Trace
     end
 
     def to_s
-      "TraceId(trace_id = #{@trace_id.to_s}, parent_id = #{@parent_id.to_s}, span_id = #{@span_id.to_s}, sampled = #{@sampled.to_s}, flags = #{@flags.to_s})"
+      "TraceId(trace_id = #{@trace_id.to_s}, parent_id = #{@parent_id.to_s}, span_id = #{@span_id.to_s}," \
+      " sampled = #{@sampled.to_s}, flags = #{@flags.to_s}, shared = #{@shared.to_s})"
     end
   end
 
@@ -209,6 +211,7 @@ module Trace
       h[:remoteEndpoint] = @remote_endpoint.to_h unless @remote_endpoint.nil?
       h[:annotations] = @annotations.map(&:to_h) unless @annotations.empty?
       h[:tags] = @tags unless @tags.empty?
+      h[:shared] = true if @span_id.shared
       h
     end
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -168,7 +168,7 @@ module Trace
       METHOD = "http.method".freeze
       PATH = "http.path".freeze
       STATUS = "http.status_code".freeze
-      LOCAL_COMPONENT = "lc".freeze
+      LOCAL_COMPONENT = "lc".freeze # TODO: Remove LOCAL_COMPONENT and related methods when no longer needed
       ERROR = "error".freeze
     end
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.32.4'.freeze
+  VERSION = '0.33.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -5,7 +5,7 @@ require 'zipkin-tracer/hostname_resolver'
 
 class AsyncJsonApiClient
   include SuckerPunch::Job
-  SPANS_PATH = '/api/v1/spans'
+  SPANS_PATH = '/api/v2/spans'
 
   def perform(json_api_host, spans)
     spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -70,7 +70,7 @@ shared_examples 'make requests' do |expect_to_trace_request|
     end
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
-      expect(key).to eq('http.status')
+      expect(key).to eq('http.status_code')
       expect(value).to eq('404')
     end
 

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -53,45 +53,30 @@ shared_examples 'make requests' do |expect_to_trace_request|
     expect(tracer).to receive(:start_span).with(anything, 'post').and_call_original
     expect(tracer).to receive(:end_span).with(anything).and_call_original
 
-    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-      expect(key).to eq('http.method')
-      expect(value).to eq('POST')
-      expect_host(host, '127.0.0.1', service_name)
-    end
+    expect_any_instance_of(Trace::Span).to receive(:kind=).with('CLIENT')
 
-    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-      expect(key).to eq('http.path')
-      expect(value).to eq(url_path)
-      expect_host(host, '127.0.0.1', service_name)
-    end
-
-    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
-      expect(key).to eq('sa')
-      expect(value).to eq(true)
-      expect(type).to eq('BOOL')
+    expect_any_instance_of(Trace::Span).to receive(:remote_endpoint=) do |_, host|
       expect_host(host, hostname, service_name)
     end
 
-    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
+      expect(key).to eq('http.method')
+      expect(value).to eq('POST')
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
+      expect(key).to eq('http.path')
+      expect(value).to eq(url_path)
+    end
+
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
       expect(key).to eq('http.status')
       expect(value).to eq('404')
-      expect_host(host, '127.0.0.1', service_name)
     end
 
-    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value, type, host|
+    expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
       expect(key).to eq('error')
       expect(value).to eq('404')
-      expect_host(host, '127.0.0.1', service_name)
-    end
-
-    expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-      expect(value).to eq(Trace::Annotation::CLIENT_SEND)
-      expect_host(host, '127.0.0.1', service_name)
-    end
-
-    expect_any_instance_of(Trace::Span).to receive(:record) do |_, value, host|
-      expect(value).to eq(Trace::Annotation::CLIENT_RECV)
-      expect_host(host, '127.0.0.1', service_name)
     end
   end
 
@@ -180,7 +165,6 @@ shared_examples 'make requests' do |expect_to_trace_request|
     end
 
     it 'does not create any annotation' do
-      expect(Trace::BinaryAnnotation).not_to receive(:new)
       expect(Trace::Annotation).not_to receive(:new)
       process('', url)
     end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -175,7 +175,7 @@ describe ZipkinTracer::RackHandler do
         # string annotation
         span.record_tag('foo', env['foo'] || 'FOO')
         # integer annotation
-        span.record_tag('http.status', status)
+        span.record_tag('http.status_code', status)
       end
     end
     subject { middleware(app, annotate_plugin: annotate) }

--- a/spec/lib/rack/zipkin_env_spec.rb
+++ b/spec/lib/rack/zipkin_env_spec.rb
@@ -83,6 +83,10 @@ describe ZipkinTracer::ZipkinEnv do
       expect(zipkin_env.trace_id.sampled?).to eq(true)
     end
 
+    it 'shared is false' do
+      expect(zipkin_env.trace_id.shared).to eq(false)
+    end
+
     context 'trace_id_128bit is true' do
       before do
         allow(Trace).to receive(:trace_id_128bit).and_return(true)
@@ -101,6 +105,10 @@ describe ZipkinTracer::ZipkinEnv do
 
     it '#called_with_zipkin_headers? returns true' do
       expect(zipkin_env.called_with_zipkin_headers?).to eq(true)
+    end
+
+    it 'shared is true' do
+      expect(zipkin_env.trace_id.shared).to eq(true)
     end
 
     context 'parent_id is not provided' do


### PR DESCRIPTION
Use the simplified Zipkin v2 span format to send traces to Zipkin server.

See https://github.com/openzipkin/zipkin/issues/1499 for details

@cabbott @jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol @piao-mdsol @adriancole