### PR TITLE
Add the ':additional_paths' configuration option to enable tracing on non-Rails-routable paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.6.0
-  - 2.5.3
+  - 2.6.2
+  - 2.5.5
   - 2.4.5
   - 2.3.8
   - jruby-9.1.6.0
@@ -15,7 +15,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
-    condition: "$TRAVIS_RUBY_VERSION == 2.6.0"
+    condition: "$TRAVIS_RUBY_VERSION == 2.6.2"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.34.0
+* Add the ':additional_paths' configuration option to enable tracing on non-Rails-routable paths
+
 # 0.33.0
 * Switch to Zipkin v2 span format
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
 * `:record_on_server_receive` - a CSV style list of tags to record on server receive, even if the zipkin headers were present in the incoming request. Currently only supports the value `http.path`, others being discarded.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
+* `:additional_paths` - A comma separated list of path prefixes (e.g. `/v1, /v2`) you want to trace in non-Rails applications.
 
 ### Sending traces on outgoing requests with Faraday
 

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -9,7 +9,7 @@ module ZipkinTracer
       :zookeeper, :sample_rate, :logger, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin,
       :sampled_as_boolean, :record_on_server_receive,
-      :kafka_producer, :kafka_topic, :trace_id_128bit
+      :kafka_producer, :kafka_topic, :trace_id_128bit, :additional_paths
 
     def initialize(app, config_hash)
       config = config_hash || Application.config(app)
@@ -26,8 +26,6 @@ module ZipkinTracer
       @sample_rate       = config[:sample_rate]       || DEFAULTS[:sample_rate]
       # A block of code which can be called to do extra annotations of traces
       @annotate_plugin   = config[:annotate_plugin]   # call for trace annotation
-      @filter_plugin     = config[:filter_plugin]     # skip tracing if returns false
-      @whitelist_plugin  = config[:whitelist_plugin]  # force sampling if returns true
       # A block of code which can be called to skip traces. Skip tracing if returns false
       @filter_plugin     = config[:filter_plugin]
       # A block of code which can be called to force sampling. Forces sampling if returns true
@@ -49,6 +47,9 @@ module ZipkinTracer
       # This makes it convertible to Amazon X-Ray trace ID format v1.
       # (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
       @trace_id_128bit = config[:trace_id_128bit].nil? ? DEFAULTS[:trace_id_128bit] : config[:trace_id_128bit]
+
+      # A comma separated list of path prefixes you want to trace in non-Rails applications.
+      @additional_paths = present?(config[:additional_paths]) ? config[:additional_paths].split(",").map(&:strip) : nil
 
       Trace.sample_rate = @sample_rate
       Trace.trace_id_128bit = @trace_id_128bit

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.33.0'.freeze
+  VERSION = '0.34.0'.freeze
 end


### PR DESCRIPTION
Add the `:additional_paths` configuration option to enable tracing on non-Rails-routable paths, such as in apps using [Roda](https://github.com/jeremyevans/roda), [Sinatra](https://github.com/sinatra/sinatra).

This is another approach to solve the issue in https://github.com/openzipkin/zipkin-ruby/pull/130

@cabbott @jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol @piao-mdsol @adriancole