### PR TITLE
Record tags inconditionally at server receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.35.0
+* removes record_on_server_receive option
+* records status_code and method on all server receive events.
+
 # 0.34.0
 * Whitelist plugin ensure a request is traced even if it is not routable
 * Gem requires Ruby > 2.3.0. In practice this was true already.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 * `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
 * `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
-* `:record_on_server_receive` - a CSV style list of tags to record on server receive, even if the zipkin headers were present in the incoming request. Currently only supports the value `http.path`, others being discarded.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
 
 ### Sending traces on outgoing requests with Faraday

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -39,8 +39,6 @@ module ZipkinTracer
       if @sampled_as_boolean
         @logger && @logger.warn("Using a boolean in the Sampled header is deprecated. Consider setting sampled_as_boolean to false")
       end
-      # Record the given tags on server receive, even if the zipkin headers were present in the incoming request?
-      @record_on_server_receive = parse_tags(config[:record_on_server_receive])
 
       # When set to true, high 8-bytes will be prepended to trace_id.
       # The upper 4-bytes are epoch seconds and the lower 4-bytes are random.
@@ -73,14 +71,6 @@ module ZipkinTracer
       sampled_as_boolean: true,
       trace_id_128bit: false
     }
-
-    def parse_tags(tag_names)
-      return {} unless present?(tag_names)
-      names = tag_names.split(",").map(&:strip)
-      (ZipkinTracer::RackHandler::DEFAULT_SERVER_RECV_TAGS.keys & names).each_with_object({}) do |name, tags|
-        tags[name] = ZipkinTracer::RackHandler::DEFAULT_SERVER_RECV_TAGS[name]
-      end
-    end
 
     def present?(str)
       return false if str.nil?

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -8,7 +8,7 @@ module ZipkinTracer
     attr_reader :service_name, :json_api_host,
       :zookeeper, :sample_rate, :logger, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin,
-      :sampled_as_boolean, :record_on_server_receive,
+      :sampled_as_boolean,
       :kafka_producer, :kafka_topic, :trace_id_128bit
 
     def initialize(app, config_hash)

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -27,8 +27,7 @@ module ZipkinTracer
 
     def response_call(datum)
       if span = datum[:span]
-        status = response_status(datum)
-        record_response_tags(span, status) if status
+        span.record_status(response_status(datum))
         Trace.tracer.end_span(span)
       end
 
@@ -36,8 +35,6 @@ module ZipkinTracer
     end
 
     private
-
-    STATUS_ERROR_REGEXP = /\A(4.*|5.*)\z/.freeze
 
     def b3_headers
       {
@@ -59,11 +56,6 @@ module ZipkinTracer
 
     def response_status(datum)
       datum[:response] && datum[:response][:status] && datum[:response][:status].to_s
-    end
-
-    def record_response_tags(span, status)
-      span.record_tag(Trace::Span::Tag::STATUS, status)
-      span.record_tag(Trace::Span::Tag::ERROR, status) if STATUS_ERROR_REGEXP.match(status)
     end
 
     def trace!(datum, trace_id)

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -25,8 +25,6 @@ module ZipkinTracer
 
     private
 
-    STATUS_ERROR_REGEXP = /\A(4.*|5.*)\z/.freeze
-
     def b3_headers
       {
         trace_id: 'X-B3-TraceId',
@@ -51,7 +49,7 @@ module ZipkinTracer
         span.record_tag(Trace::Span::Tag::METHOD, method.upcase)
         span.record_tag(Trace::Span::Tag::PATH, url.path)
         response = @app.call(env).on_complete do |renv|
-          record_response_tags(span, renv[:status].to_s)
+          span.record_status(renv[:status])
         end
       end
       response
@@ -68,11 +66,6 @@ module ZipkinTracer
 
     def record_error(span, msg)
       span.record_tag(Trace::Span::Tag::ERROR, msg)
-    end
-
-    def record_response_tags(span, status)
-      span.record_tag(Trace::Span::Tag::STATUS, status)
-      span.record_tag(Trace::Span::Tag::ERROR, status) if STATUS_ERROR_REGEXP.match(status)
     end
 
   end

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -56,7 +56,7 @@ module ZipkinTracer
 
     def trace_server_information(span, zipkin_env, status)
       span.kind = Trace::Span::Kind::SERVER
-      span.record_tag(Trace::Span::Tag::STATUS, status)
+      span.record_status(status)
       SERVER_RECV_TAGS.each { |annotation_key, env_key| span.record_tag(annotation_key, zipkin_env.env[env_key]) }
     end
   end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -221,7 +221,7 @@ module Trace
     end
 
     def record_tag(key, value)
-      @tags[key] = value
+      @tags[key] = value.to_s
     end
 
     def record_local_component(value)
@@ -230,6 +230,15 @@ module Trace
 
     def has_parent_span?
       !@span_id.parent_id.nil?
+    end
+
+    STATUS_ERROR_REGEXP = /\A(4.*|5.*)\z/.freeze
+
+    def record_status(status)
+      return if status.nil?
+      status = status.to_s
+      record_tag(Tag::STATUS, status)
+      record_tag(Tag::ERROR, status) if STATUS_ERROR_REGEXP.match(status)
     end
 
     private

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.34.0'.freeze
+  VERSION = '0.35.0'.freeze
 end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -57,7 +57,7 @@ describe 'integrations' do
     expect(traces[0]['trace_id']).not_to be_empty
     expect(traces[0]['parent_span_id']).to be_empty
     expect(traces[0]['span_id']).not_to be_empty
-    expect(['true'].include?(traces[0]['sampled'])).to be_truthy
+    expect(['1'].include?(traces[0]['sampled'])).to eq(true)
   end
 
   # Assert that the second level of trace data is correct (or not!).
@@ -68,6 +68,6 @@ describe 'integrations' do
     expect(traces[1]['parent_span_id']).to eq(traces[0]['span_id'])
     expect(traces[1]['span_id']).not_to be_empty
     expect([traces[1]['trace_id'], traces[1]['parent_span_id']].include?(traces[1]['span_id'])).to be_falsey
-    expect(['true'].include?(traces[1]['sampled'])).to be_truthy
+    expect(['1'].include?(traces[1]['sampled'])).to eq(true)
   end
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -221,10 +221,9 @@ describe ZipkinTracer::ExconHandler do
         stub_request(:get, url)
           .to_return(status: 200, body: '', headers: {})
 
-        span = spy('Trace::Span')
-        allow(Trace::Span).to receive(:new).and_return(span)
-
-        expect(span).to receive(:record_tag).with(Trace::Span::Tag::STATUS, "200").once
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', "/some/path/here")
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', '200')
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.method', 'GET')
 
         ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
           middlewares = [ZipkinTracer::ExconHandler] + Excon.defaults[:middlewares]

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -20,6 +20,13 @@ describe ZipkinTracer::RackHandler do
     expect(host.ipv4).to eq(host_ip)
   end
 
+  def expect_tags(path = '/')
+    expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
+    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', path)
+    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', 200)
+    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.method', 'GET')
+  end
+
   let(:app_status) { 200 }
   let(:app_headers) { { 'Content-Type' => 'text/plain' } }
   let(:app_body) { path }
@@ -45,33 +52,12 @@ describe ZipkinTracer::RackHandler do
     it 'traces the request' do
       expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).and_call_original
       expect(tracer).to receive(:with_new_span).ordered.with(anything, 'get').and_call_original
-      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', '/')
-      expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
+      expect_tags
 
       status, headers, body = subject.call(mock_env)
       expect(status).to eq(app_status)
       expect(headers).to eq(app_headers)
       expect { |b| body.each &b }.to yield_with_args(app_body)
-    end
-  end
-
-  context 'Zipkin headers are passed to the middleware' do
-    subject { middleware(app) }
-    let(:env) { mock_env(',', ZipkinTracer::ZipkinEnv::B3_REQUIRED_HEADERS.map {|a| Hash[a, 1] }.inject(:merge)) }
-
-    it 'does not set the RPC method' do
-      expect(::Trace).not_to receive(:set_rpc_name)
-      subject.call(env)
-    end
-
-    it 'does not set the path info' do
-      expect_any_instance_of(Trace::Span).not_to receive(:record_tag)
-      subject.call(env)
-    end
-
-    it 'force-sets the path info, excluding unknown keys' do
-      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', '/,')
-      middleware(app, record_on_server_receive: 'whatever, http.path , unknown,keys ').call(env)
     end
   end
 
@@ -96,8 +82,7 @@ describe ZipkinTracer::RackHandler do
       it 'traces the request' do
         expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).and_call_original
         expect(tracer).to receive(:with_new_span).ordered.with(anything, 'get /thing/:id').and_call_original
-        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', '/thing/123')
-        expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
+        expect_tags('/thing/123')
 
         status, headers, body = subject.call(mock_env_route)
         expect(status).to eq(app_status)
@@ -183,9 +168,10 @@ describe ZipkinTracer::RackHandler do
     it 'traces a request with additional annotations' do
       expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).and_call_original
       expect(tracer).to receive(:with_new_span).and_call_original.ordered
+      expect_tags
+      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', 200)
+      expect_any_instance_of(Trace::Span).to receive(:record_tag).with('foo', 'FOO')
 
-      expect_any_instance_of(Trace::Span).to receive(:record_tag).exactly(3).times
-      expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
       status, _, _ = subject.call(mock_env)
 
       # return expected status
@@ -216,8 +202,7 @@ describe ZipkinTracer::RackHandler do
       subject { middleware(app, whitelist_plugin: lambda { |env| true }, sample_rate: 0) }
 
       it 'samples the request' do
-        expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
-        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', '/')
+        expect_tags
         status, _, _ = subject.call(mock_env)
         expect(status).to eq(200)
       end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -23,7 +23,7 @@ describe ZipkinTracer::RackHandler do
   def expect_tags(path = '/')
     expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
     expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', path)
-    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', 200)
+    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', '200')
     expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.method', 'GET')
   end
 

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -139,7 +139,7 @@ describe Trace do
     let(:duration) { 0 }
     let(:key) { 'key' }
     let(:value) { 'value' }
-    let(:numeric_value) { 123 }
+    let(:numeric_value) { '123' }
     let(:span_without_parent) do
       Trace::Span.new('get', Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY))
     end
@@ -239,7 +239,7 @@ describe Trace do
         span_with_parent.record_tag(key, numeric_value)
 
         tags = span_with_parent.tags
-        expect(tags[key]).to eq(123)
+        expect(tags[key]).to eq('123')
       end
     end
 

--- a/spec/support/test_app_config.ru
+++ b/spec/support/test_app_config.ru
@@ -5,7 +5,8 @@ require File.join(`pwd`.chomp, 'spec', 'support', 'test_app')
 zipkin_tracer_config = {
   service_name: 'your service name here',
   sample_rate: 1,
-  json_api_host: '127.0.0.1:9410'
+  json_api_host: '127.0.0.1:9410',
+  sampled_as_boolean: false
 }
 
 use ZipkinTracer::RackHandler, zipkin_tracer_config


### PR DESCRIPTION
This removes the possibility of constraining the tags recorded at server receive. It was always half-baked and pretty useless.

We originally created the feature of optionally setting tags in server because:
- UI bugs
- Being cheap with storage

I do not think any of these hold anymore.

Also, by our own experience using zipkin more often than not we want more info not less. 

This PR also adds `status_code` and `method` alongside the `path` info to server spans so that info is available when for some reason the client spans do not have it.

@adriancole @ykitamura-mdsol @jfeltesse-mdsol 

