### PR TITLE
IP format is really a property of the tracer not of each endpoint. Move it over

### DIFF
--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -48,6 +48,10 @@ module ZipkinTracer
 
       Trace.sample_rate = @sample_rate
       Trace.trace_id_128bit = @trace_id_128bit
+
+      Trace.default_endpoint = Trace::Endpoint.local_endpoint(
+        domain_service_name(@service_name)
+      )
     end
 
     def adapter
@@ -65,6 +69,12 @@ module ZipkinTracer
     end
 
     private
+
+    # Use the Domain environment variable to extract the service name, otherwise use the default config name
+    # TODO: move to the config object
+    def domain_service_name(default_name)
+      ENV["DOMAIN"].to_s.empty? ? default_name : ENV["DOMAIN"].split('.').first
+    end
 
     DEFAULTS = {
       sample_rate: 0.1,

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -47,7 +47,7 @@ module ZipkinTracer
     end
 
     def remote_endpoint(url, service_name)
-      Trace::Endpoint.remote_endpoint(url, service_name, Trace.default_endpoint.ip_format) # The endpoint we are calling.
+      Trace::Endpoint.remote_endpoint(url, service_name) # The endpoint we are calling.
     end
 
     def service_name(datum, default)

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -40,7 +40,7 @@ module ZipkinTracer
       # handle either a URI object (passed by Faraday v0.8.x in testing), or something string-izable
       method = env[:method].to_s
       url = env[:url].respond_to?(:host) ? env[:url] : URI.parse(env[:url].to_s)
-      remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name, Trace.default_endpoint.ip_format) # The endpoint we are calling.
+      remote_endpoint = Trace::Endpoint.remote_endpoint(url, @service_name) # The endpoint we are calling.
       Trace.tracer.with_new_span(trace_id, method.downcase) do |span|
         @span = span # So we can record on exceptions
         # annotate with method (GET/POST/etc.) and uri path

--- a/lib/zipkin-tracer/hostname_resolver.rb
+++ b/lib/zipkin-tracer/hostname_resolver.rb
@@ -5,13 +5,14 @@ module ZipkinTracer
   # Resolving hostnames is a very expensive operation. We want to store them raw in the main thread
   # and resolve them in a different thread where we do not affect execution times.
   class HostnameResolver
-    def spans_with_ips(spans)
-      host_to_ip = hosts_to_ipv4(spans)
+    def spans_with_ips(spans, ip_format)
+      hosts = unique_hosts(spans)
+      resolved_hosts = resolve(hosts, ip_format)
 
       each_endpoint(spans) do |endpoint|
         hostname = endpoint.ipv4
         unless resolved_ip_address?(hostname.to_s)
-          endpoint.ipv4 = host_to_ip[hostname]
+          endpoint.ipv4 = resolved_hosts[hostname]
         end
       end
     end
@@ -19,6 +20,8 @@ module ZipkinTracer
     private
     LOCALHOST = '127.0.0.1'.freeze
     LOCALHOST_I32 = 0x7f000001.freeze
+    MAX_I32 = ((2 ** 31) - 1)
+    MASK = (2 ** 32) - 1
     IP_FIELD = 3
 
     def resolved_ip_address?(ip_string)
@@ -37,31 +40,42 @@ module ZipkinTracer
     end
 
     # Using this to resolve only once per host
-    def hosts_to_ipv4(spans)
+    def unique_hosts(spans)
       hosts = []
       each_endpoint(spans) do |endpoint|
         hosts.push(endpoint)
       end
-      hosts.uniq!
-      resolve(hosts)
+      hosts.uniq
     end
 
-    def resolve(hosts)
+    def resolve(hosts, ip_format)
       hosts.inject({}) do |host_map, host|
         hostname = host.ipv4  # This field has been temporarly used to store the hostname.
-        ip_format = host.ip_format
-        host_map[hostname]  = host_to_ip(hostname, ip_format)
+        host_map[hostname]  = host_to_format(hostname, ip_format)
         host_map
       end
     end
 
-    def host_to_ip(hostname, ip_format)
+    def host_to_format(hostname, ip_format)
       begin
-        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET).first[IP_FIELD] : Trace::Endpoint.host_to_i32(hostname)
+        ip_format == :string ? Socket.getaddrinfo(hostname, nil, :INET).first[IP_FIELD] : host_to_i32(hostname)
       rescue
         ip_format == :string ? LOCALHOST : LOCALHOST_I32
       end
     end
-  end
 
+    def host_to_i32(host)
+      unsigned_i32 = Socket.getaddrinfo(host, nil)[0][3].split(".").map do |i|
+        i.to_i
+      end.inject(0) { |a,e| (a << 8) + e }
+
+      signed_i32 = if unsigned_i32 > MAX_I32
+        -1 * ((unsigned_i32 ^ MASK) + 1)
+      else
+        unsigned_i32
+      end
+
+      signed_i32
+    end
+  end
 end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -250,33 +250,17 @@ module Trace
     end
   end
 
-  class Endpoint < Struct.new(:ipv4, :port, :service_name, :ip_format)
-    MAX_I32 = ((2 ** 31) - 1)
-    MASK = (2 ** 32) - 1
+  class Endpoint < Struct.new(:ipv4, :port, :service_name)
     UNKNOWN_URL = 'unknown'.freeze
 
-    def self.host_to_i32(host)
-      unsigned_i32 = Socket.getaddrinfo(host, nil)[0][3].split(".").map do |i|
-        i.to_i
-      end.inject(0) { |a,e| (a << 8) + e }
-
-      signed_i32 = if unsigned_i32 > MAX_I32
-        -1 * ((unsigned_i32 ^ MASK) + 1)
-      else
-        unsigned_i32
-      end
-
-      signed_i32
-    end
-
-    def self.local_endpoint(service_name, ip_format)
+    def self.local_endpoint(service_name)
       hostname = Socket.gethostname
-      Endpoint.new(hostname, nil, service_name, ip_format)
+      Endpoint.new(hostname, nil, service_name)
     end
 
-    def self.remote_endpoint(url, remote_service_name, ip_format)
+    def self.remote_endpoint(url, remote_service_name)
       service_name = remote_service_name || url.host.split('.').first || UNKNOWN_URL # default to url-derived service name
-      Endpoint.new(url.host, url.port, service_name, ip_format)
+      Endpoint.new(url.host, url.port, service_name)
     end
 
     def to_h

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -25,19 +25,8 @@ module ZipkinTracer
       end
       Trace.tracer = tracer
 
-      # TODO: move this to the TracerBase and kill scribe tracer
-      ip_format = [:kafka, :kafka_producer].include?(config.adapter) ? :i32 : :string
-      Trace.default_endpoint = Trace::Endpoint.local_endpoint(
-        service_name(config.service_name),
-        ip_format
-      )
       tracer
     end
 
-    # Use the Domain environment variable to extract the service name, otherwise use the default config name
-    # TODO: move to the config object
-    def service_name(default_name)
-      ENV["DOMAIN"].to_s.empty? ? default_name : ENV["DOMAIN"].split('.').first
-    end
   end
 end

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -8,7 +8,8 @@ class AsyncJsonApiClient
   SPANS_PATH = '/api/v2/spans'
 
   def perform(json_api_host, spans)
-    spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinJsonTracer::IP_FORMAT).map(&:to_h)
+    spans_with_ips =
+      ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinJsonTracer::IP_FORMAT).map(&:to_h)
     resp = Faraday.new(json_api_host).post do |req|
       req.url SPANS_PATH
       req.headers['Content-Type'] = 'application/json'

--- a/lib/zipkin-tracer/zipkin_json_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_json_tracer.rb
@@ -8,7 +8,7 @@ class AsyncJsonApiClient
   SPANS_PATH = '/api/v2/spans'
 
   def perform(json_api_host, spans)
-    spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
+    spans_with_ips = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinJsonTracer::IP_FORMAT).map(&:to_h)
     resp = Faraday.new(json_api_host).post do |req|
       req.url SPANS_PATH
       req.headers['Content-Type'] = 'application/json'
@@ -27,6 +27,7 @@ module Trace
   # This class sends information to the Zipkin API.
   # The API accepts a JSON representation of a list of spans
   class ZipkinJsonTracer < ZipkinTracerBase
+    IP_FORMAT = :string
 
     def initialize(options)
       SuckerPunch.logger = options[:logger]

--- a/lib/zipkin-tracer/zipkin_kafka_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_tracer.rb
@@ -14,6 +14,7 @@ module Trace
   # Spans are encoded using Thrift
   class ZipkinKafkaTracer < ZipkinTracerBase
     DEFAULT_KAFKA_TOPIC = "zipkin".freeze
+    IP_FORMAT = :i32
 
     def initialize(options = {})
       @topic  = options[:topic] || DEFAULT_KAFKA_TOPIC
@@ -29,7 +30,7 @@ module Trace
     end
 
     def flush!
-      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans)
+      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, IP_FORMAT)
       resolved_spans.each do |span|
         buf = ''
         trans = Thrift::MemoryBufferTransport.new(buf)

--- a/lib/zipkin-tracer/zipkin_logger_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_logger_tracer.rb
@@ -5,6 +5,7 @@ require 'json'
 module Trace
   class ZipkinLoggerTracer < ZipkinTracerBase
     TRACING_KEY = 'Tracing information'
+    IP_FORMAT = :string
 
     def initialize(options)
       @logger = options[:logger]
@@ -13,7 +14,7 @@ module Trace
     end
 
     def flush!
-      formatted_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans).map(&:to_h)
+      formatted_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, IP_FORMAT).map(&:to_h)
       if @logger_accepts_data
         @logger.info_with_data(TRACING_KEY, formatted_spans)
       else

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -13,12 +13,6 @@ module Trace
       reset
     end
 
-    # This is the common format: IP
-    # Overwrite this method to use different format in this tracer.
-    def ip_format
-      :string
-    end
-
     def with_new_span(trace_id, name)
       span = start_span(trace_id, name)
       result = yield span

--- a/lib/zipkin-tracer/zipkin_tracer_base.rb
+++ b/lib/zipkin-tracer/zipkin_tracer_base.rb
@@ -13,6 +13,12 @@ module Trace
       reset
     end
 
+    # This is the common format: IP
+    # Overwrite this method to use different format in this tracer.
+    def ip_format
+      :string
+    end
+
     def with_new_span(trace_id, name)
       span = start_span(trace_id, name)
       result = yield span

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -91,6 +91,40 @@ module ZipkinTracer
           expect(config.adapter).to eq(:kafka_producer)
         end
       end
+
+      context 'no domain environment variable' do
+        before do
+          ENV['DOMAIN'] = ''
+        end
+
+        it 'sets the trace endpoint service name to the default configuration file value' do
+          expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-tester') { 'endpoint' }
+          expect(Trace).to receive(:default_endpoint=).with('endpoint')
+          Config.new(nil, service_name: 'zipkin-tester')
+        end
+
+        context 'json adapter' do
+          let(:config) { { service_name: 'zipkin-tester', json_api_host: 'host' } }
+          it 'calls with string ip format' do
+            expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-tester') { 'endpoint' }
+            expect(Trace).to receive(:default_endpoint=).with('endpoint')
+            Config.new(nil, config)
+          end
+        end
+      end
+
+      context 'domain environment variable initialized' do
+        let(:config) { { service_name: 'zipkin-tester' } }
+        before do
+          ENV['DOMAIN'] = 'zipkin-env-var-tester.example.com'
+        end
+
+        it 'sets the trace endpoint service name to the environment variable value' do
+          expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-env-var-tester') { 'endpoint' }
+          expect(Trace).to receive(:default_endpoint=).with('endpoint')
+          Config.new(nil, config)
+        end
+      end
     end
   end
 end

--- a/spec/lib/trace_spec.rb
+++ b/spec/lib/trace_spec.rb
@@ -276,8 +276,8 @@ describe Trace do
     describe '.local_endpoint' do
       it 'auto detects the hostname' do
         allow(Socket).to receive(:gethostname).and_return('z1.example.com')
-        expect(Trace::Endpoint).to receive(:new).with('z1.example.com', nil, service_name, :string)
-        Trace::Endpoint.local_endpoint(service_name, :string)
+        expect(Trace::Endpoint).to receive(:new).with('z1.example.com', nil, service_name)
+        Trace::Endpoint.local_endpoint(service_name)
       end
     end
 
@@ -293,9 +293,8 @@ describe Trace do
         end
 
         it 'does not translate the hostname' do
-          ep = ::Trace::Endpoint.new(hostname, 80, service_name, :string)
+          ep = ::Trace::Endpoint.new(hostname, 80, service_name)
           expect(ep.ipv4).to eq(hostname)
-          expect(ep.ip_format).to eq(:string)
         end
       end
     end

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -80,39 +80,5 @@ describe ZipkinTracer::TracerFactory do
       end
     end
 
-    context 'no domain environment variable' do
-      let(:config) { configuration(service_name: 'zipkin-tester') }
-      before do
-        ENV['DOMAIN'] = ''
-      end
-
-      it 'sets the trace endpoint service name to the default configuration file value' do
-        expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-tester', :string) { 'endpoint' }
-        expect(Trace).to receive(:default_endpoint=).with('endpoint')
-        described_class.new.tracer(config)
-      end
-
-      context 'json adapter' do
-        let(:config) { configuration(service_name: 'zipkin-tester', json_api_host: 'host') }
-        it 'calls with string ip format' do
-          expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-tester', :string) { 'endpoint' }
-          expect(Trace).to receive(:default_endpoint=).with('endpoint')
-          described_class.new.tracer(config)
-        end
-      end
-    end
-
-    context 'domain environment variable initialized' do
-      let(:config) { configuration(service_name: 'zipkin-tester') }
-      before do
-        ENV['DOMAIN'] = 'zipkin-env-var-tester.example.com'
-      end
-
-      it 'sets the trace endpoint service name to the environment variable value' do
-        expect(Trace::Endpoint).to receive(:local_endpoint).with('zipkin-env-var-tester', :string) { 'endpoint' }
-        expect(Trace).to receive(:default_endpoint=).with('endpoint')
-        described_class.new.tracer(config)
-      end
-    end
   end
 end


### PR DESCRIPTION
Also setup the default endpoint in config not in the tracer factory which should not manufacture other thing than tracers.

No functional changes

@ykitamura-mdsol @jfeltesse-mdsol @adriancole 
