### PR TITLE
Add ZipkinSqsTracer to send spans via Amazon SQS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.36.0
-* Add ZipkinSqsTracer to send spans via Amazon SQS
+* Add ZipkinSqsSender to send spans via Amazon SQS
+* Rename ZipkinJsonTracer to ZipkinHttpSender and rename others to replace the term "tracer" with "sender"
 
 # 0.35.1
 * Fix bug with Rails 5.1 when calling recognize_path with a nil path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.36.0
+* Add ZipkinSqsTracer to send spans via Amazon SQS
+
 # 0.35.1
 * Fix bug with Rails 5.1 when calling recognize_path with a nil path
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the fo
 
 * `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
-* `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the JSON tracer
-* `:zookeeper` - the address of the zookeeper server to use by the Kafka tracer
-* `:sqs_queue_name` - the name of the Amazon SQS queue to use the SQS tracer
+* `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender
+* `:zookeeper` - the address of the zookeeper server to use by the Kafka sender
+* `:sqs_queue_name` - the name of the Amazon SQS queue to use the SQS sender
 * `:sqs_region` - the AWS region for the Amazon SQS queue
 * `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
 * `:annotate_plugin` - plugin function which receives the Rack env, the response status, headers, and body to record annotations
@@ -97,13 +97,13 @@ end
 ```
 
 
-## Tracers
+## Senders
 
-Only one of the following tracers can be used at a given time.
+Only one of the following senders can be used at a given time.
 
-### JSON
+### HTTP
 
-Sends traces as JSON over HTTP. This is the preferred tracer to use as the openzipkin project moves away from Thrift.
+Sends traces as JSON over HTTP. This is the preferred sender to use as the openzipkin project moves away from Thrift.
 
 You need to specify the `:json_api_host` parameter to wherever your zipkin collector is running. It will POST traces to the `/api/v2/spans` path.
 
@@ -137,14 +137,14 @@ Optionally, you can set `:sqs_region` to specify the AWS region to connect to.
 
 ### Logger
 
-The simplest tracer that does something. It will log all your spans.
-This tracer can be used for debugging purpose (to see what is going to be sent) or to deliver zipkin information into the logs for later retrieval and analysis.
+The simplest sender that does something. It will log all your spans.
+This sender can be used for debugging purpose (to see what is going to be sent) or to deliver zipkin information into the logs for later retrieval and analysis.
 
 You need to set `:log_tracing` to true in the configuration.
 
 ### Null
 
-If the configuration does not provide either a JSON host, Zookeeper server or Amazon SQS queue then the middlewares will not attempt to send traces although they will still generate proper IDs and pass them to other services.
+If the configuration does not provide either an API host, Zookeeper server or Amazon SQS queue then the middlewares will not attempt to send traces although they will still generate proper IDs and pass them to other services.
 
 Thus, if you only want to generate IDs for instance for logging and do not intent to integrate with Zipkin you can still use this gem. Just do not specify any server :)
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -1,4 +1,4 @@
-require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/trace_container'
 # Most of this code is copied from Finagle
 # https://github.com/twitter/finagle/blob/finagle-6.39.0/finagle-thrift/src/main/ruby/lib/finagle-thrift/trace.rb

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -5,27 +5,27 @@ module ZipkinTracer
 
       tracer = case adapter
         when :json
-          require 'zipkin-tracer/zipkin_json_tracer'
+          require 'zipkin-tracer/zipkin_http_sender'
           options = { json_api_host: config.json_api_host, logger: config.logger }
-          Trace::ZipkinJsonTracer.new(options)
+          Trace::ZipkinHttpSender.new(options)
         when :kafka
-          require 'zipkin-tracer/zipkin_kafka_tracer'
-          Trace::ZipkinKafkaTracer.new(zookeepers: config.zookeeper)
+          require 'zipkin-tracer/zipkin_kafka_sender'
+          Trace::ZipkinKafkaSender.new(zookeepers: config.zookeeper)
         when :kafka_producer
-          require 'zipkin-tracer/zipkin_kafka_tracer'
+          require 'zipkin-tracer/zipkin_kafka_sender'
           options = { producer: config.kafka_producer }
           options[:topic] = config.kafka_topic unless config.kafka_topic.nil?
-          Trace::ZipkinKafkaTracer.new(options)
+          Trace::ZipkinKafkaSender.new(options)
         when :sqs
-          require 'zipkin-tracer/zipkin_sqs_tracer'
+          require 'zipkin-tracer/zipkin_sqs_sender'
           options = { logger: config.logger, queue_name: config.sqs_queue_name , region: config.sqs_region }
-          Trace::ZipkinSqsTracer.new(options)
+          Trace::ZipkinSqsSender.new(options)
         when :logger
-          require 'zipkin-tracer/zipkin_logger_tracer'
-          Trace::ZipkinLoggerTracer.new(logger: config.logger)
+          require 'zipkin-tracer/zipkin_logger_sender'
+          Trace::ZipkinLoggerSender.new(logger: config.logger)
         else
-          require 'zipkin-tracer/zipkin_null_tracer'
-          Trace::NullTracer.new
+          require 'zipkin-tracer/zipkin_null_sender'
+          Trace::NullSender.new
       end
       Trace.tracer = tracer
 

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -16,6 +16,10 @@ module ZipkinTracer
           options = { producer: config.kafka_producer }
           options[:topic] = config.kafka_topic unless config.kafka_topic.nil?
           Trace::ZipkinKafkaTracer.new(options)
+        when :sqs
+          require 'zipkin-tracer/zipkin_sqs_tracer'
+          options = { logger: config.logger, queue_name: config.sqs_queue_name , region: config.sqs_region }
+          Trace::ZipkinSqsTracer.new(options)
         when :logger
           require 'zipkin-tracer/zipkin_logger_tracer'
           Trace::ZipkinLoggerTracer.new(logger: config.logger)
@@ -27,6 +31,5 @@ module ZipkinTracer
 
       tracer
     end
-
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.35.1'.freeze
+  VERSION = '0.36.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_http_sender.rb
+++ b/lib/zipkin-tracer/zipkin_http_sender.rb
@@ -1,15 +1,15 @@
 require 'json'
 require 'sucker_punch'
-require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/hostname_resolver'
 
-class AsyncJsonApiClient
+class AsyncHttpApiClient
   include SuckerPunch::Job
   SPANS_PATH = '/api/v2/spans'
 
   def perform(json_api_host, spans)
     spans_with_ips =
-      ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinJsonTracer::IP_FORMAT).map(&:to_h)
+      ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinHttpSender::IP_FORMAT).map(&:to_h)
     resp = Faraday.new(json_api_host).post do |req|
       req.url SPANS_PATH
       req.headers['Content-Type'] = 'application/json'
@@ -27,7 +27,7 @@ end
 module Trace
   # This class sends information to the Zipkin API.
   # The API accepts a JSON representation of a list of spans
-  class ZipkinJsonTracer < ZipkinTracerBase
+  class ZipkinHttpSender < ZipkinSenderBase
     IP_FORMAT = :string
 
     def initialize(options)
@@ -37,7 +37,7 @@ module Trace
     end
 
     def flush!
-      AsyncJsonApiClient.perform_async(@json_api_host, spans.dup)
+      AsyncHttpApiClient.perform_async(@json_api_host, spans.dup)
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_kafka_sender.rb
+++ b/lib/zipkin-tracer/zipkin_kafka_sender.rb
@@ -6,13 +6,13 @@ begin
 rescue LoadError => e
 end
 
-require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/hostname_resolver'
 
 module Trace
   # This class sends information to Zipkin through Kafka.
   # Spans are encoded using Thrift
-  class ZipkinKafkaTracer < ZipkinTracerBase
+  class ZipkinKafkaSender < ZipkinSenderBase
     DEFAULT_KAFKA_TOPIC = "zipkin".freeze
     IP_FORMAT = :i32
 

--- a/lib/zipkin-tracer/zipkin_logger_sender.rb
+++ b/lib/zipkin-tracer/zipkin_logger_sender.rb
@@ -1,9 +1,9 @@
-require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/hostname_resolver'
 require 'json'
 
 module Trace
-  class ZipkinLoggerTracer < ZipkinTracerBase
+  class ZipkinLoggerSender < ZipkinSenderBase
     TRACING_KEY = 'Tracing information'
     IP_FORMAT = :string
 

--- a/lib/zipkin-tracer/zipkin_null_sender.rb
+++ b/lib/zipkin-tracer/zipkin_null_sender.rb
@@ -1,8 +1,5 @@
 module Trace
-  # Monkey patching Nulltracer from thrift.
-  # All our tracers have a start_span method, adding it to
-  # the NullTracer also.
-  class NullTracer
+  class NullSender
     def with_new_span(trace_id, name)
       span = start_span(trace_id, name)
       result = yield span

--- a/lib/zipkin-tracer/zipkin_sender_base.rb
+++ b/lib/zipkin-tracer/zipkin_sender_base.rb
@@ -1,12 +1,12 @@
 require 'faraday'
 
 module Trace
-  # This class is a base for tracers sending information to Zipkin.
+  # This class is a base for senders sending information to Zipkin.
   # It knows about zipkin types of annotations and send traces when the server
   # is done with its request
-  # Traces dealing with zipkin should inherit from this class and implement the
+  # Senders dealing with zipkin should inherit from this class and implement the
   # flush! method which actually sends the information
-  class ZipkinTracerBase
+  class ZipkinSenderBase
 
     def initialize(options={})
       @options = options

--- a/lib/zipkin-tracer/zipkin_sqs_sender.rb
+++ b/lib/zipkin-tracer/zipkin_sqs_sender.rb
@@ -1,10 +1,10 @@
 require "aws-sdk-sqs"
 require "json"
-require "zipkin-tracer/zipkin_tracer_base"
+require "zipkin-tracer/zipkin_sender_base"
 require "zipkin-tracer/hostname_resolver"
 
 module Trace
-  class ZipkinSqsTracer < ZipkinTracerBase
+  class ZipkinSqsSender < ZipkinSenderBase
     IP_FORMAT = :string
 
     def initialize(options)

--- a/lib/zipkin-tracer/zipkin_sqs_sender.rb
+++ b/lib/zipkin-tracer/zipkin_sqs_sender.rb
@@ -1,29 +1,39 @@
 require "aws-sdk-sqs"
 require "json"
+require 'sucker_punch'
 require "zipkin-tracer/zipkin_sender_base"
 require "zipkin-tracer/hostname_resolver"
 
 module Trace
+  class AsyncSqsClient
+    include SuckerPunch::Job
+
+    def perform(sqs_options, queue_name, spans)
+      spans_with_ips =
+        ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinSqsSender::IP_FORMAT).map(&:to_h)
+      sqs = Aws::SQS::Client.new(**sqs_options)
+      queue_url = sqs.get_queue_url(queue_name: queue_name).queue_url
+      sqs.send_message(queue_url: queue_url, message_body: JSON.generate(spans_with_ips))
+    rescue Aws::SQS::Errors::NonExistentQueue
+      error_message = "A queue named '#{@queue_name}' does not exist."
+      SuckerPunch.logger.error(error_message)
+    rescue => e
+      SuckerPunch.logger.error(e)
+    end
+  end
+
   class ZipkinSqsSender < ZipkinSenderBase
     IP_FORMAT = :string
 
     def initialize(options)
-      sqs_options = options[:region] ? { region: options[:region] } : {}
-      @sqs = Aws::SQS::Client.new(**sqs_options)
+      @sqs_options = options[:region] ? { region: options[:region] } : {}
       @queue_name = options[:queue_name]
-      @logger = options[:logger]
+      SuckerPunch.logger = options[:logger]
       super(options)
     end
 
     def flush!
-      queue_url = @sqs.get_queue_url(queue_name: @queue_name).queue_url
-      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, IP_FORMAT).map(&:to_h)
-      @sqs.send_message(queue_url: queue_url, message_body: JSON.generate(resolved_spans))
-    rescue Aws::SQS::Errors::NonExistentQueue
-      error_message = "A queue named '#{@queue_name}' does not exist."
-      @logger.error(error_message)
-    rescue => e
-      @logger.error(e)
+      AsyncSqsClient.perform_async(@sqs_options, @queue_name, spans.dup)
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_sqs_tracer.rb
+++ b/lib/zipkin-tracer/zipkin_sqs_tracer.rb
@@ -1,0 +1,29 @@
+require "aws-sdk-sqs"
+require "json"
+require "zipkin-tracer/zipkin_tracer_base"
+require "zipkin-tracer/hostname_resolver"
+
+module Trace
+  class ZipkinSqsTracer < ZipkinTracerBase
+    IP_FORMAT = :string
+
+    def initialize(options)
+      sqs_options = options[:region] ? { region: options[:region] } : {}
+      @sqs = Aws::SQS::Client.new(**sqs_options)
+      @queue_name = options[:queue_name]
+      @logger = options[:logger]
+      super(options)
+    end
+
+    def flush!
+      queue_url = @sqs.get_queue_url(queue_name: @queue_name).queue_url
+      resolved_spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, IP_FORMAT).map(&:to_h)
+      @sqs.send_message(queue_url: queue_url, message_body: JSON.generate(resolved_spans))
+    rescue Aws::SQS::Errors::NonExistentQueue
+      error_message = "A queue named '#{@queue_name}' does not exist."
+      @logger.error(error_message)
+    rescue => e
+      @logger.error(e)
+    end
+  end
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -92,6 +92,24 @@ module ZipkinTracer
         end
       end
 
+      context 'sqs' do
+        context 'Aws::SQS is defined' do
+          it 'returns :sqs if sqs_queue_name has been set' do
+            config = Config.new(nil, sqs_queue_name: 'zipkin-sqs')
+            expect(config.adapter).to eq(:sqs)
+          end
+        end
+
+        context 'Aws::SQS is not defined' do
+          before { hide_const('Aws::SQS') }
+
+          it 'does not return :sqs' do
+            config = Config.new(nil, sqs_queue_name: 'zipkin-sqs')
+            expect(config.adapter).to eq(nil)
+          end
+        end
+      end
+
       context 'no domain environment variable' do
         before do
           ENV['DOMAIN'] = ''

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'zipkin-tracer/zipkin_null_tracer'
+require 'zipkin-tracer/zipkin_null_sender'
 require 'lib/middleware_shared_examples'
 
 describe ZipkinTracer::ExconHandler do
@@ -54,7 +54,7 @@ describe ZipkinTracer::ExconHandler do
   it 'has a trace with correct duration' do
     request_duration_in_seconds = 1
     Timecop.freeze
-    Trace.tracer = Trace::NullTracer.new
+    Trace.tracer = Trace::NullSender.new
     ::Trace.sample_rate = 1
     trace_id = ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG)
     url = 'https://www.example.com'
@@ -98,7 +98,7 @@ describe ZipkinTracer::ExconHandler do
 
     context 'request with path and query params' do
       around do |example|
-        Trace.tracer = Trace::NullTracer.new
+        Trace.tracer = Trace::NullSender.new
         ::Trace.sample_rate = 1 # make sure initialized
         ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
           example.run
@@ -172,7 +172,7 @@ describe ZipkinTracer::ExconHandler do
 
     context 'request with custom zipkin service name' do
       around do |example|
-        Trace.tracer = Trace::NullTracer.new
+        Trace.tracer = Trace::NullSender.new
         ::Trace.sample_rate = 1 # make sure initialized
         ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
           example.run

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'zipkin-tracer/zipkin_null_tracer'
+require 'zipkin-tracer/zipkin_null_sender'
 require 'lib/middleware_shared_examples'
 
 describe ZipkinTracer::FaradayHandler do

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -10,7 +10,7 @@ shared_examples 'makes requests without tracing' do
   end
   context 'We are not sampling this request' do
     before do
-      Trace.tracer = Trace::NullTracer.new
+      Trace.tracer = Trace::NullSender.new
       ::Trace.sample_rate = 0 # make sure initialized
     end
     include_examples 'make requests', false
@@ -19,7 +19,7 @@ end
 
 shared_examples 'makes requests with tracing' do
   around do |example|
-    Trace.tracer = Trace::NullTracer.new
+    Trace.tracer = Trace::NullSender.new
     ::Trace.sample_rate = 1 # make sure initialized
     ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
       example.run

--- a/spec/lib/trace_client_spec.rb
+++ b/spec/lib/trace_client_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'zipkin-tracer/zipkin_null_tracer'
+require 'zipkin-tracer/zipkin_null_sender'
 
 describe ZipkinTracer::TraceClient do
   let(:lc_value) { 'lc_value' }
@@ -7,7 +7,7 @@ describe ZipkinTracer::TraceClient do
   subject { ZipkinTracer::TraceClient }
 
   before do
-    Trace.tracer = Trace::NullTracer.new
+    Trace.tracer = Trace::NullSender.new
     allow(Trace).to receive(:default_endpoint).and_return(Trace::Endpoint.new('127.0.0.1', '80', 'service_name'))
     Trace.sample_rate = 1
     ZipkinTracer::TraceContainer.cleanup!

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -62,6 +62,15 @@ describe ZipkinTracer::TracerFactory do
       end
     end
 
+    context 'configured to use Amazon SQS' do
+      let(:config) { configuration(sqs_queue_name: 'zipkin-sqs') }
+
+      it 'creates a sqs tracer' do
+        allow(Trace::ZipkinSqsTracer).to receive(:new) { tracer }
+        expect(Trace).to receive(:tracer=).with(tracer)
+        expect(described_class.new.tracer(config)).to eq(tracer)
+      end
+    end
 
     context 'no transport configured' do
       it 'creates a null tracer' do
@@ -70,7 +79,8 @@ describe ZipkinTracer::TracerFactory do
           { json_api_host: nil },
           { json_api_host: "" },
           { json_api_host: "\n\t 　\r" },
-          { zookeeper: "" }
+          { zookeeper: "" },
+          { sqs_queue_name: "" }
         ].each do |options|
           config = configuration(options)
           allow(Trace::NullTracer).to receive(:new) { tracer }

--- a/spec/lib/tracer_factory_spec.rb
+++ b/spec/lib/tracer_factory_spec.rb
@@ -18,7 +18,7 @@ describe ZipkinTracer::TracerFactory do
 
   let(:logger) { Logger.new(nil) }
   let(:subject) { described_class.new(config) }
-  let(:tracer) { double('Trace::NullTracer') }
+  let(:tracer) { double('Trace::NullSender') }
 
   before do
     allow(ZipkinTracer::Application).to receive(:logger).and_return(logger)
@@ -31,7 +31,6 @@ describe ZipkinTracer::TracerFactory do
         require 'zipkin-tracer/zipkin_kafka_sender'
 
         let(:zookeeper) { 'localhost:2181' }
-        let(:zipkinKafkaTracer) { double('ZipkinKafkaTracer') }
         let(:config) { configuration(zookeeper: zookeeper) }
 
         it 'creates a zipkin kafka sender' do

--- a/spec/lib/zipkin_http_sender_spec.rb
+++ b/spec/lib/zipkin_http_sender_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'zipkin-tracer/zipkin_json_tracer'
+require 'zipkin-tracer/zipkin_http_sender'
 
-describe Trace::ZipkinJsonTracer do
+describe Trace::ZipkinHttpSender do
   let(:json_api_host) { 'http://json.example.com' }
   let(:default_options) { { json_api_host: json_api_host } }
 

--- a/spec/lib/zipkin_kafka_sender_spec.rb
+++ b/spec/lib/zipkin_kafka_sender_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 if RUBY_PLATFORM == 'java'
   require 'zipkin-tracer/zipkin_kafka_sender'
 
-  describe Trace::ZipkinKafkaTracer, :platform => :java do
+  describe Trace::ZipkinKafkaSender, :platform => :java do
     let(:span_id) { 'c3a555b04cf7e099' }
     let(:parent_id) { 'f0e71086411b1445' }
     let(:sampled) { true }
@@ -32,7 +32,7 @@ if RUBY_PLATFORM == 'java'
         end
 
         it 'has default topic' do
-          expect(tracer.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaTracer::DEFAULT_KAFKA_TOPIC
+          expect(tracer.instance_variable_get(:@topic)).to eq Trace::ZipkinKafkaSender::DEFAULT_KAFKA_TOPIC
         end
 
         it 'connects to zookeeper to create a Hermann producer' do

--- a/spec/lib/zipkin_kafka_sender_spec.rb
+++ b/spec/lib/zipkin_kafka_sender_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # needed the if statement because rspec tags are broken
 if RUBY_PLATFORM == 'java'
-  require 'zipkin-tracer/zipkin_kafka_tracer'
+  require 'zipkin-tracer/zipkin_kafka_sender'
 
   describe Trace::ZipkinKafkaTracer, :platform => :java do
     let(:span_id) { 'c3a555b04cf7e099' }

--- a/spec/lib/zipkin_logger_sender_spec.rb
+++ b/spec/lib/zipkin_logger_sender_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'securerandom'
-require 'zipkin-tracer/zipkin_logger_tracer'
+require 'zipkin-tracer/zipkin_logger_sender'
 
-describe Trace::ZipkinLoggerTracer do
+describe Trace::ZipkinLoggerSender do
   let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
   let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
   let(:name) { 'trusmis' }

--- a/spec/lib/zipkin_logger_tracer_spec.rb
+++ b/spec/lib/zipkin_logger_tracer_spec.rb
@@ -7,21 +7,19 @@ describe Trace::ZipkinLoggerTracer do
   let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
   let(:name) { 'trusmis' }
   let(:logger) { Logger.new(nil) }
+  let(:tracer) { described_class.new(logger: logger) }
+  let(:span) { tracer.start_span(trace_id, name) }
 
   describe '#flush!' do
+    before { Timecop.freeze }
+
     it 'flushes the list of spans into the log' do
-      tracer = described_class.new(logger: logger)
-      span = tracer.start_span(trace_id, name)
+      span.record_tag('test', 'prueba')
+      spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([span], described_class::IP_FORMAT).map(&:to_h)
+      log_text = { described_class::TRACING_KEY => spans }.to_json
+      expect(logger).to receive(:info).with(log_text)
 
-      tracer.end_span(span)do |span|
-        the_span = span
-        span.record_tag('test', 'prueba')
-        span.close
-
-        spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([the_span]).map(&:to_h)
-        log_text = { described_class::TRACING_KEY => spans }.to_json
-        expect(logger).to receive(:info).with(log_text)
-      end
+      tracer.end_span(span)
     end
   end
 end

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'zipkin-tracer/zipkin_tracer_base'
+require 'zipkin-tracer/zipkin_sender_base'
 
-describe Trace::ZipkinTracerBase do
+describe Trace::ZipkinSenderBase do
   let(:span_id) { 'c3a555b04cf7e099' }
   let(:parent_id) { 'f0e71086411b1445' }
   let(:sampled) { true }

--- a/spec/lib/zipkin_sqs_sender_spec.rb
+++ b/spec/lib/zipkin_sqs_sender_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require "zipkin-tracer/zipkin_sqs_tracer"
+require "zipkin-tracer/zipkin_sqs_sender"
 
-describe Trace::ZipkinSqsTracer do
+describe Trace::ZipkinSqsSender do
   let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
   let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
   let(:queue_name) { "zipkin-sqs" }

--- a/spec/lib/zipkin_sqs_sender_spec.rb
+++ b/spec/lib/zipkin_sqs_sender_spec.rb
@@ -10,19 +10,22 @@ describe Trace::ZipkinSqsSender do
   let(:tracer) { described_class.new(logger: logger, queue_name: queue_name, region: region) }
 
   describe "#initialize" do
+    it 'sets the SuckerPunch logger' do
+      expect(SuckerPunch).to receive(:logger=).with(logger)
+      tracer
+    end
+
     context "without region" do
-      it "creates a new instance without region" do
-        expect(Aws::SQS::Client).to receive(:new).with({})
-        tracer
+      it "does not set region in sqs_options" do
+        expect(tracer.instance_variable_get(:@sqs_options)).to eq({})
       end
     end
 
     context "with region" do
       let(:region) { "us-west-2"}
 
-      it "creates a new instance with the given region" do
-        expect(Aws::SQS::Client).to receive(:new).with(region: "us-west-2")
-        tracer
+      it "sets region in sqs_options" do
+        expect(tracer.instance_variable_get(:@sqs_options)).to eq(region: "us-west-2")
       end
     end
   end

--- a/spec/lib/zipkin_sqs_tracer_spec.rb
+++ b/spec/lib/zipkin_sqs_tracer_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+require "zipkin-tracer/zipkin_sqs_tracer"
+
+describe Trace::ZipkinSqsTracer do
+  let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
+  let(:queue_name) { "zipkin-sqs" }
+  let(:region) { nil }
+  let(:logger) { Logger.new(nil) }
+  let(:tracer) { described_class.new(logger: logger, queue_name: queue_name, region: region) }
+
+  describe "#initialize" do
+    context "without region" do
+      it "creates a new instance without region" do
+        expect(Aws::SQS::Client).to receive(:new).with({})
+        tracer
+      end
+    end
+
+    context "with region" do
+      let(:region) { "us-west-2"}
+
+      it "creates a new instance with the given region" do
+        expect(Aws::SQS::Client).to receive(:new).with(region: "us-west-2")
+        tracer
+      end
+    end
+  end
+
+  describe "#flush!" do
+    before do
+      Aws.config[:sqs] = {
+        stub_responses: {
+          get_queue_url: {
+            queue_url: "http://#{queue_name}.com"
+          }
+        }
+      }
+      Timecop.freeze
+    end
+
+    let(:name) { "test" }
+    let(:span) { tracer.start_span(trace_id, name) }
+
+    it "flushes the list of spans to SQS" do
+      spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([span], described_class::IP_FORMAT).map(&:to_h)
+      expect_any_instance_of(Aws::SQS::Client)
+        .to receive(:send_message).with(queue_url: "http://#{queue_name}.com", message_body: spans.to_json)
+      tracer.end_span(span)
+    end
+  end
+end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 
+  s.add_development_dependency 'aws-sdk-sqs', '~> 1.0'
   s.add_development_dependency 'excon', '~> 0.53'
   s.add_development_dependency 'rspec', '~> 3.8'
   s.add_development_dependency 'rack-test', '~> 1.1'


### PR DESCRIPTION
Added the [sender-sqs](https://github.com/openzipkin/zipkin-aws/tree/master/sender-sqs) like feature  to be able to send spans via Amazon SQS.

This is NOT solving the #136 issue.

@cabbott @jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol @piao-mdsol @adriancole