### PR TITLE
Bugfix: Prevent uninitialized constant AsyncHttpApiClient::ZipkinHttpSender error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.36.1
+* Bugfix: Prevent uninitialized constant AsyncHttpApiClient::ZipkinHttpSender error
+
 # 0.36.0
 * Add ZipkinSqsSender to send spans via Amazon SQS
 * Rename ZipkinJsonTracer to ZipkinHttpSender and rename others to replace the term "tracer" with "sender"

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.36.0'.freeze
+  VERSION = '0.36.1'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_http_sender.rb
+++ b/lib/zipkin-tracer/zipkin_http_sender.rb
@@ -3,28 +3,29 @@ require 'sucker_punch'
 require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/hostname_resolver'
 
-class AsyncHttpApiClient
-  include SuckerPunch::Job
-  SPANS_PATH = '/api/v2/spans'
-
-  def perform(json_api_host, spans)
-    spans_with_ips =
-      ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinHttpSender::IP_FORMAT).map(&:to_h)
-    resp = Faraday.new(json_api_host).post do |req|
-      req.url SPANS_PATH
-      req.headers['Content-Type'] = 'application/json'
-      req.body = JSON.generate(spans_with_ips)
-    end
-  rescue Net::ReadTimeout, Faraday::ConnectionFailed => e
-    error_message = "Error while connecting to #{json_api_host}: #{e.class.inspect} with message '#{e.message}'. " \
-                    "Please make sure the URL / port are properly specified for the Zipkin server."
-    SuckerPunch.logger.error(error_message)
-  rescue => e
-    SuckerPunch.logger.error(e)
-  end
-end
-
 module Trace
+  class AsyncHttpApiClient
+    include SuckerPunch::Job
+    SPANS_PATH = '/api/v2/spans'
+
+    def perform(json_api_host, spans)
+      spans_with_ips =
+        ::ZipkinTracer::HostnameResolver.new.spans_with_ips(spans, ZipkinHttpSender::IP_FORMAT).map(&:to_h)
+
+      resp = Faraday.new(json_api_host).post do |req|
+        req.url SPANS_PATH
+        req.headers['Content-Type'] = 'application/json'
+        req.body = JSON.generate(spans_with_ips)
+      end
+    rescue Net::ReadTimeout, Faraday::ConnectionFailed => e
+      error_message = "Error while connecting to #{json_api_host}: #{e.class.inspect} with message '#{e.message}'. " \
+                      "Please make sure the URL / port are properly specified for the Zipkin server."
+      SuckerPunch.logger.error(error_message)
+    rescue => e
+      SuckerPunch.logger.error(e)
+    end
+  end
+
   # This class sends information to the Zipkin API.
   # The API accepts a JSON representation of a list of spans
   class ZipkinHttpSender < ZipkinSenderBase

--- a/spec/lib/zipkin_http_sender_spec.rb
+++ b/spec/lib/zipkin_http_sender_spec.rb
@@ -2,15 +2,33 @@ require 'spec_helper'
 require 'zipkin-tracer/zipkin_http_sender'
 
 describe Trace::ZipkinHttpSender do
+  let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, true, Trace::Flags::EMPTY) }
   let(:json_api_host) { 'http://json.example.com' }
-  let(:default_options) { { json_api_host: json_api_host } }
+  let(:logger) { Logger.new(nil) }
+  let(:tracer) { described_class.new(json_api_host: json_api_host, logger: logger) }
 
   describe '#initialize' do
-    let(:logger) { nil }
     it 'sets the SuckerPunch logger' do
       expect(SuckerPunch).to receive(:logger=).with(logger)
-      described_class.new(default_options.merge(logger: logger))
+      tracer
     end
   end
 
+  describe "#flush!" do
+    before do
+      Timecop.freeze
+      stub_request(:post, /json.example.com/).to_return(status: 200)
+    end
+
+    let(:name) { "test" }
+    let(:span) { tracer.start_span(trace_id, name) }
+
+    it "flushes the list of spans to API" do
+      spans = ::ZipkinTracer::HostnameResolver.new.spans_with_ips([span], described_class::IP_FORMAT).map(&:to_h)
+      expect_any_instance_of(Faraday::Connection).to receive(:post).and_call_original
+      expect_any_instance_of(Faraday::Request).to receive(:body=).with(spans.to_json)
+      tracer.end_span(span)
+    end
+  end
 end


### PR DESCRIPTION
Seems [this change](https://github.com/openzipkin/zipkin-ruby/pull/145/files#diff-919d6e0235b077303b52907834bdedd8R12) introduced a bug, raising the following errors when sending traces to zipkin server:
```
uninitialized constant AsyncJsonApiClient::ZipkinJsonTracer
uninitialized constant AsyncHttpApiClient::ZipkinHttpSender
```

There is no spec to cover, so I also added it.

@adriancole Can you yank 0.35.1 and 0.36.0?

@cabbott @jcarres-mdsol @jfeltesse-mdsol @ssteeg-mdsol @piao-mdsol