### PR TITLE
cleanup the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.36.2
+* Cleanup the gemspec. No code changes.
+
 # 0.36.1
 * Bugfix: Prevent uninitialized constant AsyncHttpApiClient::ZipkinHttpSender error
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.36.1'.freeze
+  VERSION = '0.36.2'.freeze
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -1,24 +1,28 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib/', __FILE__)
-$:.unshift lib unless $:.include?(lib)
-
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'zipkin-tracer/version'
 
 Gem::Specification.new do |s|
-  s.name                      = 'zipkin-tracer'
-  s.version                   = ZipkinTracer::VERSION
-  s.authors                   = ['Franklin Hu', 'R Tyler Croy', 'James Way', 'Jordi Polo', 'Julien Feltesse', 'Scott Steeg']
-  s.email                     = ['franklin@twitter.com', 'tyler@monkeypox.org', 'jamescway@gmail.com', 'jcarres@mdsol.com', 'jfeltesse@mdsol.com', 'ssteeg@mdsol.com']
-  s.homepage                  = 'https://github.com/openzipkin/zipkin-tracer'
-  s.summary                   = 'Ruby tracing via Zipkin'
-  s.description               = 'Adds tracing instrumentation for ruby applications'
-  s.license                   = 'Apache-2.0'
+  s.name        = 'zipkin-tracer'
+  s.version     = ZipkinTracer::VERSION
+  s.authors     = ['Franklin Hu', 'R Tyler Croy', 'James Way', 'Jordi Polo', 'Julien Feltesse', 'Scott Steeg', 'Yohei Kitamura']
+  s.email       = ['franklin@twitter.com', 'tyler@monkeypox.org', 'jamescway@gmail.com', 'jcarres@medidata.com', 'jfeltesse@medidata.com', 'ssteeg@medidata.com', 'ykitamura@medidata.com']
+  s.summary     = 'Ruby tracing via Zipkin'
+  s.description = 'Adds tracing instrumentation for ruby applications'
+  s.license     = 'Apache-2.0'
+  s.metadata    = {
+    'homepage_uri'  => 'https://github.com/openzipkin/zipkin-ruby',
+    'changelog_uri' => 'https://github.com/openzipkin/zipkin-ruby/blob/master/CHANGELOG.md'
+  }
 
-  s.required_rubygems_version = '>= 1.3.5'
-  s.required_ruby_version     = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.3.0'
 
-  s.files                     = Dir.glob('{bin,lib}/**/*')
-  s.require_path              = 'lib'
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  s.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  s.require_paths = ['lib']
 
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'rack', '>= 1.0'


### PR DESCRIPTION
## Highlights

- use metadata to specify the homepage and changelog URI
  - the current links are incorrect (homepage `github.com/openzipkin/zipkin-tracer`, source code `openzipkin/zipkin-ruby.git`)
  - rubygems doesn't support setting links elsewhere anymore, from [this post](https://blog.rubygems.org/2019/03/08/and-then-there-was-one-metadata-links.html):
    > As of now, if you need to update any of the sidebar links previously editable from the UI, you would have to set a few URI attributes in spec.metadata
  - source code link not needed as it'd be the same as the homepage
- removed `required_rubygems_version`, we're requiring ruby 2.3 and it [ships with rubygems 2.5.1](https://github.com/ruby/ruby/blob/v2_3_0/NEWS)
- updated the contributors list (added Yohei, mdsol.com → medidata.com)

## Question

I believe bumping the version is the only way to have those links fixed on rubygems.org, let me know if otherwise.

@adriancole @cabbott @jcarres-mdsol @ykitamura-mdsol  @ssteeg-mdsol @piao-mdsol