### PR TITLE
Annotate http.url instead of http.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.37.0
+* Annotate http.url instead of http.path.
+
 # 0.36.2
 * Cleanup the gemspec. No code changes.
 

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -4,8 +4,8 @@ module ZipkinTracer
     # Determines if our framework knows whether the request will be routed to a controller
     def self.routable_request?(env)
       return true unless defined?(Rails) # If not running on a Rails app, we can't verify if it is invalid
-      path_info = env[ZipkinTracer::RackHandler::PATH_INFO] || ""
-      http_method = env[ZipkinTracer::RackHandler::REQUEST_METHOD]
+      path_info = env[Rack::PATH_INFO] || ""
+      http_method = env[Rack::REQUEST_METHOD]
       Rails.application.routes.recognize_path(path_info, method: http_method)
       true
     rescue ActionController::RoutingError
@@ -15,8 +15,8 @@ module ZipkinTracer
     def self.route(env)
       return nil unless defined?(Rails)
       stub_env = {
-        "PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO],
-        "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD]
+        "PATH_INFO" => env[Rack::PATH_INFO],
+        "REQUEST_METHOD" => env[Rack::REQUEST_METHOD]
       }
       req = Rack::Request.new(stub_env)
       # Returns a string like /some/path/:id

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -69,7 +69,7 @@ module ZipkinTracer
       span.kind = Trace::Span::Kind::CLIENT
       span.remote_endpoint = remote_endpoint(url, service_name)
       span.record_tag(Trace::Span::Tag::METHOD, method.upcase)
-      span.record_tag(Trace::Span::Tag::PATH, url.path)
+      span.record_tag(Trace::Span::Tag::URL, url.to_s)
 
       # store the span in the datum hash so it can be used in the response_call
       datum[:span] = span

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -47,7 +47,7 @@ module ZipkinTracer
         span.kind = Trace::Span::Kind::CLIENT
         span.remote_endpoint = remote_endpoint
         span.record_tag(Trace::Span::Tag::METHOD, method.upcase)
-        span.record_tag(Trace::Span::Tag::PATH, url.path)
+        span.record_tag(Trace::Span::Tag::URL, url.to_s)
         response = @app.call(env).on_complete do |renv|
           span.record_status(renv[:status])
         end

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -20,6 +20,10 @@ module ZipkinTracer
       @called_with_zipkin_headers ||= B3_REQUIRED_HEADERS.all? { |key| @env.key?(key) }
     end
 
+    def url
+      Rack::Request.new(env).url
+    end
+
     private
 
     B3_REQUIRED_HEADERS = %w(HTTP_X_B3_TRACEID HTTP_X_B3_SPANID).freeze

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -167,6 +167,7 @@ module Trace
     module Tag
       METHOD = "http.method".freeze
       PATH = "http.path".freeze
+      URL = "http.url".freeze
       STATUS = "http.status_code".freeze
       LOCAL_COMPONENT = "lc".freeze # TODO: Remove LOCAL_COMPONENT and related methods when no longer needed
       ERROR = "error".freeze

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.36.2'.freeze
+  VERSION = '0.37.0'.freeze
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -135,7 +135,7 @@ describe ZipkinTracer::ExconHandler do
           span = spy('Trace::Span')
           allow(Trace::Span).to receive(:new).and_return(span)
 
-          expect(span).to receive(:record_tag).with("http.path", "/some/path/here")
+          expect(span).to receive(:record_tag).with("http.url", url.to_s)
 
           ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
             connection.request
@@ -145,9 +145,10 @@ describe ZipkinTracer::ExconHandler do
 
       context 'query params are in hash' do
         let(:url_path) { '/some/path/here' }
+        let(:whole_url) { url.to_s + "?query=params" }
 
         it 'queries without the query even when query is a hash' do
-          stub_request(:post, url.to_s + "?query=params")
+          stub_request(:post, whole_url)
             .to_return(status: 200, body: '', headers: {})
           ENV['ZIPKIN_SERVICE_NAME'] = service_name
 
@@ -161,7 +162,7 @@ describe ZipkinTracer::ExconHandler do
           span = spy('Trace::Span')
           allow(Trace::Span).to receive(:new).and_return(span)
 
-          expect(span).to receive(:record_tag).with("http.path", "/some/path/here")
+          expect(span).to receive(:record_tag).with("http.url", whole_url)
 
           ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
             connection.request(path: url_path, query: { query: "params" })
@@ -221,7 +222,7 @@ describe ZipkinTracer::ExconHandler do
         stub_request(:get, url)
           .to_return(status: 200, body: '', headers: {})
 
-        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', "/some/path/here")
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.url', url.to_s)
         expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', '200')
         expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.method', 'GET')
 

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -38,7 +38,8 @@ shared_examples 'make requests' do |expect_to_trace_request|
   let(:hostname) { 'service.example.com' }
   let(:host_ip) { 0x11223344 }
   let(:url_path) { '/some/path/here' }
-  let(:raw_url) { "https://#{hostname}#{url_path}" }
+  let(:query_params) { 'param=param_value' }
+  let(:raw_url) { URI::HTTP.build(host: hostname, path: url_path, query: query_params).to_s }
   let(:tracer) { Trace.tracer }
   let(:trace_id) { ::Trace::TraceId.new(1, 2, 3, true, ::Trace::Flags::DEBUG) }
 
@@ -65,8 +66,8 @@ shared_examples 'make requests' do |expect_to_trace_request|
     end
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|
-      expect(key).to eq('http.path')
-      expect(value).to eq(url_path)
+      expect(key).to eq('http.url')
+      expect(value).to eq(raw_url)
     end
 
     expect_any_instance_of(Trace::Span).to receive(:record_tag) do |_, key, value|

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -21,8 +21,9 @@ describe ZipkinTracer::RackHandler do
   end
 
   def expect_tags(path = '/')
+    url = "http://example.org#{path}"
     expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::SERVER)
-    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.path', path)
+    expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.url', url)
     expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.status_code', '200')
     expect_any_instance_of(Trace::Span).to receive(:record_tag).with('http.method', 'GET')
   end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'faraday', '~> 0.8'
-  s.add_dependency 'rack', '>= 1.0'
+  s.add_dependency 'rack', '>= 1.6'
   s.add_dependency 'sucker_punch', '~> 2.0'
 
   s.add_development_dependency 'aws-sdk-sqs', '~> 1.0'


### PR DESCRIPTION
I do not care about the host but I want the query parameters and could not find another standard annotation better than `url`. 
In many cases query parameters are key to understand why a particular request is slow.
For instance if you control pagination via query parameters you may be requesting a huge amount of data. Or if you do some complex filtering on your query params you may be requesting a very complex set that requires lots of processing.

@ykitamura-mdsol  @adriancole
