### PR TITLE
accept :async and :logger options, add a TraceWrapper utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 0.37.0
-* Add an `async` option
-  * only used by the SQS sender now.
+* Add an `async` option to the HTTP and SQS senders.
 * Allow the `logger` option to be provided.
 * Add the TraceWrapper utility class.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.37.0
+* Add an `async` option
+  * only used by the SQS sender now.
+* Allow the `logger` option to be provided.
+* Add the TraceWrapper utility class.
+
 # 0.36.2
 * Cleanup the gemspec. No code changes.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Sidekiq.configure_server do |config|
 end
 ```
 
-By default workers aren't traced. you can specify the workers that you want to trace with traceable_workers config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all]).
+By default workers aren't traced. You can specify the workers that you want to trace with traceable_workers config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all]).
 
 ### Local tracing
 
@@ -224,7 +224,7 @@ lambda { |env| KNOWN_DEVICES.include?(env['HTTP_X_DEVICE_ID']) }
 This class provides a `.wrap_in_custom_span` method which expects a configuration hash, a span name and a block.
 You may also pass a span kind and an Application object using respectively `span_kind:` and `app:` keyword arguments.
 
-The block You pass will be executed in the context of a custom span.
+The block you pass will be executed in the context of a custom span.
 This is useful when your application doesn't use the rack handler but still needs to generate complete traces, for instance background jobs or lambdas calling remote services.
 
 The following code will create a trace starting with a span of the (default) `SERVER` kind named "custom span" and then a span of the `CLIENT` kind will be added by the Faraday middleware. Afterwards the configured sender will call `flush!`.

--- a/README.md
+++ b/README.md
@@ -8,27 +8,34 @@ Rack and Faraday integration middlewares for Zipkin tracing.
 
 ### Sending traces on incoming requests
 
-Options can be provided via Rails.config for a Rails 3+ app, or can be passed as a hash argument to the Rack plugin.
+Options can be provided as a hash via `Rails.config.zipkin_tracer` for Rails apps or directly to the Rack middleware:
 
 ```ruby
 require 'zipkin-tracer'
-use ZipkinTracer::RackHandler, config # config is optional
+use ZipkinTracer::RackHandler, config
 ```
 
-where `Rails.config.zipkin_tracer` or `config` is a hash that can contain the following keys:
+### Configuration options
 
-* `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
-* `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
-* `:json_api_host` - hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender
-* `:zookeeper` - the address of the zookeeper server to use by the Kafka sender
-* `:sqs_queue_name` - the name of the Amazon SQS queue to use the SQS sender
-* `:sqs_region` - the AWS region for the Amazon SQS queue
-* `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
-* `:annotate_plugin` - plugin function which receives the Rack env, the response status, headers, and body to record annotations
-* `:filter_plugin` - plugin function which receives the Rack env and will skip tracing if it returns false
-* `:whitelist_plugin` - plugin function which receives the Rack env and will force sampling if it returns true
-* `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
-* `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
+#### Common
+- `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
+- `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
+- `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
+- `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
+- `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the SQS sender.
+- `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
+
+#### Sender specific
+- `:json_api_host` - Hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender
+- `:zookeeper` - The address of the zookeeper server to use by the Kafka sender
+- `:sqs_queue_name` - The name of the Amazon SQS queue to use the SQS sender
+- `:sqs_region` - The AWS region for the Amazon SQS queue (optional)
+- `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
+
+#### Plugins
+* `:annotate_plugin` - Receives the Rack env, the response status, headers, and body to record annotations
+* `:filter_plugin` - Receives the Rack env and will skip tracing if it returns false
+* `:whitelist_plugin` - Receives the Rack env and will force sampling if it returns true
 
 ### Sending traces on outgoing requests with Faraday
 
@@ -209,6 +216,29 @@ For example:
 # sample if request header specifies known device identifier
 lambda { |env| KNOWN_DEVICES.include?(env['HTTP_X_DEVICE_ID']) }
 ```
+
+## Utility classes
+
+### TraceWrapper
+
+This class provides a `.wrap_in_custom_span` method which expects a configuration hash, a span name and a block.
+You may also pass a span kind and an Application object using respectively `span_kind:` and `app:` keyword arguments.
+
+The block You pass will be executed in the context of a custom span.
+This is useful when your application doesn't use the rack handler but still needs to generate complete traces, for instance background jobs or lambda calling remote services.
+
+The following code will create a trace starting with a span of the (default) `SERVER` kind named "custom span" and then a span of the `CLIENT` kind will be added by the Faraday middleware. Afterwards the configured sender will call `flush!`.
+
+```ruby
+TraceWrapper.wrap_in_custom_span(config, "custom span") do
+  conn = Faraday.new(url: remote_service_url) do |builder|
+    builder.use ZipkinTracer::FaradayHandler, config[:service_name]
+    builder.adapter Faraday.default_adapter
+  end
+  conn.get("/")
+end
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ use ZipkinTracer::RackHandler, config
 ### Configuration options
 
 #### Common
-- `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
-- `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
-- `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
-- `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
-- `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the SQS sender.
-- `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
+* `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
+* `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
+* `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
+* `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
+* `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the SQS sender.
+* `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
 
 #### Sender specific
-- `:json_api_host` - Hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender
-- `:zookeeper` - The address of the zookeeper server to use by the Kafka sender
-- `:sqs_queue_name` - The name of the Amazon SQS queue to use the SQS sender
-- `:sqs_region` - The AWS region for the Amazon SQS queue (optional)
-- `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
+* `:json_api_host` - Hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender
+* `:zookeeper` - The address of the zookeeper server to use by the Kafka sender
+* `:sqs_queue_name` - The name of the Amazon SQS queue to use the SQS sender
+* `:sqs_region` - The AWS region for the Amazon SQS queue (optional)
+* `:log_tracing` - Set to true to log all traces. Only used if traces are not sent to the API or Kafka.
 
 #### Plugins
 * `:annotate_plugin` - Receives the Rack env, the response status, headers, and body to record annotations
@@ -82,7 +82,7 @@ Sidekiq.configure_server do |config|
 end
 ```
 
-By default workers aren't traced. You can specify the workers that you want to trace with traceable_workers config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all]).
+By default workers aren't traced. you can specify the workers that you want to trace with traceable_workers config option. If you want all your workers to be traced pass [:all] to traceable_workers option (traceable_workers: [:all]).
 
 ### Local tracing
 
@@ -225,12 +225,12 @@ This class provides a `.wrap_in_custom_span` method which expects a configuratio
 You may also pass a span kind and an Application object using respectively `span_kind:` and `app:` keyword arguments.
 
 The block You pass will be executed in the context of a custom span.
-This is useful when your application doesn't use the rack handler but still needs to generate complete traces, for instance background jobs or lambda calling remote services.
+This is useful when your application doesn't use the rack handler but still needs to generate complete traces, for instance background jobs or lambdas calling remote services.
 
 The following code will create a trace starting with a span of the (default) `SERVER` kind named "custom span" and then a span of the `CLIENT` kind will be added by the Faraday middleware. Afterwards the configured sender will call `flush!`.
 
 ```ruby
-TraceWrapper.wrap_in_custom_span(config, "custom span") do
+TraceWrapper.wrap_in_custom_span(config, "custom span") do |span|
   conn = Faraday.new(url: remote_service_url) do |builder|
     builder.use ZipkinTracer::FaradayHandler, config[:service_name]
     builder.adapter Faraday.default_adapter

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use ZipkinTracer::RackHandler, config
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
-* `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the SQS sender.
+* `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP and SQS senders.
 * `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
 
 #### Sender specific

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "zipkin-tracer"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -4,11 +4,12 @@ require 'zipkin-tracer/sidekiq/middleware'
 require 'zipkin-tracer/trace_client'
 require 'zipkin-tracer/trace_container'
 require 'zipkin-tracer/trace_generator'
+require 'zipkin-tracer/trace_wrapper'
 
 begin
   require 'faraday'
   require 'zipkin-tracer/faraday/zipkin-tracer'
-rescue LoadError #Faraday is not available, we do not load our code.
+rescue LoadError # Faraday is not available, we do not load our code.
 end
 
 begin

--- a/lib/zipkin-tracer/trace_wrapper.rb
+++ b/lib/zipkin-tracer/trace_wrapper.rb
@@ -8,9 +8,13 @@ module ZipkinTracer
       trace_id = ZipkinTracer::TraceGenerator.new.next_trace_id
 
       ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
-        tracer.with_new_span(trace_id, span_name) do |span|
-          span.kind = span_kind
-          yield
+        if trace_id.sampled?
+          tracer.with_new_span(trace_id, span_name) do |span|
+            span.kind = span_kind
+            yield(span)
+          end
+        else
+          yield(ZipkinTracer::NullSpan.new)
         end
       end
     end

--- a/lib/zipkin-tracer/trace_wrapper.rb
+++ b/lib/zipkin-tracer/trace_wrapper.rb
@@ -1,0 +1,18 @@
+module ZipkinTracer
+  class TraceWrapper
+    def self.wrap_in_custom_span(config, span_name, span_kind: Trace::Span::Kind::SERVER, app: nil)
+      raise ArgumentError, "you must provide a block" unless block_given?
+
+      zipkin_config = ZipkinTracer::Config.new(app, config).freeze
+      tracer = ZipkinTracer::TracerFactory.new.tracer(zipkin_config)
+      trace_id = ZipkinTracer::TraceGenerator.new.next_trace_id
+
+      ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
+        tracer.with_new_span(trace_id, span_name) do |span|
+          span.kind = span_kind
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/zipkin-tracer/tracer_factory.rb
+++ b/lib/zipkin-tracer/tracer_factory.rb
@@ -18,7 +18,12 @@ module ZipkinTracer
           Trace::ZipkinKafkaSender.new(options)
         when :sqs
           require 'zipkin-tracer/zipkin_sqs_sender'
-          options = { logger: config.logger, queue_name: config.sqs_queue_name , region: config.sqs_region }
+          options = {
+            async: config.async,
+            logger: config.logger,
+            queue_name: config.sqs_queue_name,
+            region: config.sqs_region
+          }
           Trace::ZipkinSqsSender.new(options)
         when :logger
           require 'zipkin-tracer/zipkin_logger_sender'

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.36.2'.freeze
+  VERSION = '0.37.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_http_sender.rb
+++ b/lib/zipkin-tracer/zipkin_http_sender.rb
@@ -4,7 +4,7 @@ require 'zipkin-tracer/zipkin_sender_base'
 require 'zipkin-tracer/hostname_resolver'
 
 module Trace
-  class AsyncHttpApiClient
+  class HttpApiClient
     include SuckerPunch::Job
     SPANS_PATH = '/api/v2/spans'
 
@@ -32,13 +32,18 @@ module Trace
     IP_FORMAT = :string
 
     def initialize(options)
-      SuckerPunch.logger = options[:logger]
       @json_api_host = options[:json_api_host]
+      @async = options[:async] != false
+      SuckerPunch.logger = options[:logger]
       super(options)
     end
 
     def flush!
-      AsyncHttpApiClient.perform_async(@json_api_host, spans.dup)
+      if @async
+        HttpApiClient.perform_async(@json_api_host, spans.dup)
+      else
+        HttpApiClient.new.perform(@json_api_host, spans.dup)
+      end
     end
   end
 end

--- a/lib/zipkin-tracer/zipkin_http_sender.rb
+++ b/lib/zipkin-tracer/zipkin_http_sender.rb
@@ -42,7 +42,7 @@ module Trace
       if @async
         HttpApiClient.perform_async(@json_api_host, spans.dup)
       else
-        HttpApiClient.new.perform(@json_api_host, spans.dup)
+        HttpApiClient.new.perform(@json_api_host, spans)
       end
     end
   end

--- a/lib/zipkin-tracer/zipkin_sqs_sender.rb
+++ b/lib/zipkin-tracer/zipkin_sqs_sender.rb
@@ -38,7 +38,7 @@ module Trace
       if @async
         SqsClient.perform_async(@sqs_options, @queue_name, spans.dup)
       else
-        SqsClient.new.perform(@sqs_options, @queue_name, spans.dup)
+        SqsClient.new.perform(@sqs_options, @queue_name, spans)
       end
     end
   end

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -8,6 +8,7 @@ shared_examples 'makes requests without tracing' do
     end
     include_examples 'make requests', false
   end
+
   context 'We are not sampling this request' do
     before do
       Trace.tracer = Trace::NullSender.new
@@ -25,16 +26,16 @@ shared_examples 'makes requests with tracing' do
       example.run
     end
   end
+
   before do
     allow(::Trace).to receive(:default_endpoint).and_return(::Trace::Endpoint.new('127.0.0.1', '80', service_name))
     allow(::Trace::Endpoint).to receive(:host_to_i32).with(hostname).and_return(host_ip)
   end
-   include_examples 'make requests', true
+
+  include_examples 'make requests', true
 end
 
-
 shared_examples 'make requests' do |expect_to_trace_request|
-
   let(:hostname) { 'service.example.com' }
   let(:host_ip) { 0x11223344 }
   let(:url_path) { '/some/path/here' }
@@ -114,7 +115,6 @@ shared_examples 'make requests' do |expect_to_trace_request|
   end
 
   context 'without tracing id' do
-
     it 'expects tracing' do
       if expect_to_trace_request
         expect_tracing
@@ -183,6 +183,5 @@ shared_examples 'make requests' do |expect_to_trace_request|
         process('', url)
       end
     end
-
   end
 end

--- a/spec/lib/trace_wrapper_spec.rb
+++ b/spec/lib/trace_wrapper_spec.rb
@@ -23,6 +23,21 @@ describe ZipkinTracer::TraceWrapper do
       expect { described_class.wrap_in_custom_span(config, "custom span") }.to raise_error(ArgumentError)
     end
 
+    it "passes back a NullSpan if the trace is not sampled" do
+      config[:sample_rate] = 0
+      described_class.wrap_in_custom_span(config, "custom span") do |span|
+        expect(span).to be_instance_of(ZipkinTracer::NullSpan)
+      end
+    end
+
+    it "passes back the custom span if the trace is sampled" do
+      described_class.wrap_in_custom_span(config, "custom span") do |span|
+        expect(span).to be_instance_of(Trace::Span)
+        expect(span.name).to eq("custom span")
+        expect(span.kind).to eq("SERVER")
+      end
+    end
+
     it "wraps the given block in a custom span" do
       trace_id = nil
       described_class.wrap_in_custom_span(config, "custom span") do

--- a/spec/lib/trace_wrapper_spec.rb
+++ b/spec/lib/trace_wrapper_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+require "rspec/json_expectations"
+
+describe ZipkinTracer::TraceWrapper do
+  describe ".wrap_in_custom_span" do
+    let(:service_url) { "http://service.example.com" }
+    let(:zipkin_url) { "http://zipkin.example.com/api/v2/spans" }
+    let(:config) do
+      {
+        async: false,
+        service_name: "some_service",
+        sample_rate: 1,
+        json_api_host: zipkin_url
+      }
+    end
+
+    before do
+      stub_request(:get, service_url)
+      stub_request(:post, zipkin_url)
+    end
+
+    it "raises if no block is given" do
+      expect { described_class.wrap_in_custom_span(config, "custom span") }.to raise_error(ArgumentError)
+    end
+
+    it "wraps the given block in a custom span" do
+      trace_id = nil
+      described_class.wrap_in_custom_span(config, "custom span") do
+        conn = Faraday.new(url: service_url) do |builder|
+          builder.use ZipkinTracer::FaradayHandler, config[:service_name]
+          builder.adapter Faraday.default_adapter
+        end
+        conn.get("/")
+        trace_id = ZipkinTracer::TraceContainer.current.trace_id.to_s
+      end
+
+      expect(WebMock).to have_requested(:get, service_url)
+        .with(
+          headers: {
+            "X-B3-Traceid" => trace_id,
+            "X-B3-Parentspanid" => trace_id,
+            "X-B3-Spanid" => /.+/
+          }
+        )
+
+      expect(WebMock).to have_requested(:post, zipkin_url)
+        .with(
+          body: include_json(
+            [
+              {
+                name: "custom span",
+                kind: "SERVER",
+                traceId: trace_id
+              },
+              {
+                name: "get",
+                kind: "CLIENT",
+                traceId: trace_id
+              }
+            ]
+          )
+        )
+    end
+  end
+end

--- a/spec/lib/zipkin_http_sender_spec.rb
+++ b/spec/lib/zipkin_http_sender_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'zipkin-tracer/zipkin_http_sender'
 
 describe Trace::ZipkinHttpSender do
@@ -12,6 +13,14 @@ describe Trace::ZipkinHttpSender do
     it 'sets the SuckerPunch logger' do
       expect(SuckerPunch).to receive(:logger=).with(logger)
       tracer
+    end
+  end
+
+  describe ":async option" do
+    include_examples "async option passed to senders" do
+      let(:sender_class) { described_class }
+      let(:job_class) { Trace::HttpApiClient }
+      let(:options) { { json_api_host: json_api_host, logger: logger } }
     end
   end
 

--- a/spec/lib/zipkin_sqs_sender_spec.rb
+++ b/spec/lib/zipkin_sqs_sender_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "support/shared_examples"
 require "zipkin-tracer/zipkin_sqs_sender"
 
 describe Trace::ZipkinSqsSender do
@@ -31,29 +32,10 @@ describe Trace::ZipkinSqsSender do
   end
 
   describe ":async option" do
-    context "default value" do
-      it "runs asynchronously" do
-        expect(Trace::SqsClient).to receive(:perform_async)
-        tracer.flush!
-      end
-    end
-
-    context ":async is anything but a boolean with a value of 'false'" do
-      it "runs asynchronously" do
-        [nil, 0, "", " ", [], {}].each do |value|
-          tracer = described_class.new(logger: logger, queue_name: queue_name, region: region, async: value)
-          expect(Trace::SqsClient).to receive(:perform_async)
-          tracer.flush!
-        end
-      end
-    end
-
-    context ":async is a boolean with a value of 'false'" do
-      it "runs synchronously" do
-        tracer = described_class.new(logger: logger, queue_name: queue_name, region: region, async: false)
-        expect(Trace::SqsClient).to receive_message_chain(:new, :perform)
-        tracer.flush!
-      end
+    include_examples "async option passed to senders" do
+      let(:sender_class) { described_class }
+      let(:job_class) { Trace::SqsClient }
+      let(:options) { { queue_name: queue_name, region: region, logger: logger } }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'sucker_punch/testing/inline'
 
 RSpec.configure do |config|
   config.order = :random
+  Kernel.srand config.seed
   RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 
   config.after(:each) do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,26 @@
+RSpec.shared_examples "async option passed to senders" do
+  context "default value" do
+    it "runs asynchronously" do
+      expect(job_class).to receive(:perform_async)
+      tracer.flush!
+    end
+  end
+
+  context ":async is anything but a boolean with a value of 'false'" do
+    it "runs asynchronously" do
+      [nil, 0, "", " ", [], {}].each do |value|
+        tracer = sender_class.new(options.merge(async: value))
+        expect(job_class).to receive(:perform_async)
+        tracer.flush!
+      end
+    end
+  end
+
+  context ":async is a boolean with a value of 'false'" do
+    it "runs synchronously" do
+      tracer = sender_class.new(options.merge(async: false))
+      expect(job_class).to receive_message_chain(:new, :perform)
+      tracer.flush!
+    end
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,6 +1,8 @@
 RSpec.shared_examples "async option passed to senders" do
   context "default value" do
     it "runs asynchronously" do
+      tracer = sender_class.new(options)
+      expect(Thread.current[:zipkin_spans]).to receive(:dup).and_call_original
       expect(job_class).to receive(:perform_async)
       tracer.flush!
     end
@@ -10,6 +12,7 @@ RSpec.shared_examples "async option passed to senders" do
     it "runs asynchronously" do
       [nil, 0, "", " ", [], {}].each do |value|
         tracer = sender_class.new(options.merge(async: value))
+        expect(Thread.current[:zipkin_spans]).to receive(:dup).and_call_original
         expect(job_class).to receive(:perform_async)
         tracer.flush!
       end
@@ -19,6 +22,7 @@ RSpec.shared_examples "async option passed to senders" do
   context ":async is a boolean with a value of 'false'" do
     it "runs synchronously" do
       tracer = sender_class.new(options.merge(async: false))
+      expect(Thread.current[:zipkin_spans]).not_to receive(:dup)
       expect(job_class).to receive_message_chain(:new, :perform)
       tracer.flush!
     end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'aws-sdk-sqs', '~> 1.0'
   s.add_development_dependency 'excon', '~> 0.53'
   s.add_development_dependency 'rspec', '~> 3.8'
+  s.add_development_dependency 'rspec-json_expectations', '~> 2.2'
   s.add_development_dependency 'rack-test', '~> 1.1'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop', '~> 0.8'


### PR DESCRIPTION
See the README about the added/modified options and that utility class.

At the same time I add the standard `bin/` utilities that one would get from bundler upon generating a new gem skeleton.
`bin/console` makes quick prototyping easier.

@jcarres-mdsol @ykitamura-mdsol @ssteeg-mdsol @adriancole 