### PR TITLE
denote the RabbitMQ sender supports the :async parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use ZipkinTracer::RackHandler, config
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
-* `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP and SQS senders.
+* `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP, RabbitMQ, and SQS senders.
 * `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
 
 #### Sender specific


### PR DESCRIPTION
all in the title.

@jcarres-mdsol 	@ssteeg-mdsol 	@adriancole 	