### PR TITLE
Allow clients to pass in explicit start and end timestamps to spans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 jdk:
   - oraclejdk8
 rvm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.39.0
+* Allow clients to provide an explicit timestamp when starting and stopping spans
+
 # 0.38.0
 * Add RabbitMQ sender
 

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -179,7 +179,7 @@ module Trace
 
     attr_accessor :name, :kind, :local_endpoint, :remote_endpoint, :annotations, :tags, :debug
 
-    def initialize(name, span_id)
+    def initialize(name, span_id, timestamp = Time.now)
       @name = name
       @span_id = span_id
       @kind = nil
@@ -188,12 +188,12 @@ module Trace
       @annotations = []
       @tags = {}
       @debug = span_id.debug?
-      @timestamp = to_microseconds(Time.now)
+      @timestamp = to_microseconds(timestamp)
       @duration = UNKNOWN_DURATION
     end
 
-    def close
-      @duration = to_microseconds(Time.now) - @timestamp
+    def close(timestamp = Time.now)
+      @duration = to_microseconds(timestamp) - @timestamp
     end
 
     def to_h

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.38.0'.freeze
+  VERSION = '0.39.0'.freeze
 end

--- a/lib/zipkin-tracer/zipkin_null_sender.rb
+++ b/lib/zipkin-tracer/zipkin_null_sender.rb
@@ -7,12 +7,12 @@ module Trace
       result
     end
 
-    def start_span(trace_id, name)
-      Span.new(name, trace_id)
+    def start_span(trace_id, name, timestamp = Time.now)
+      Span.new(name, trace_id, timestamp)
     end
 
-    def end_span(span)
-      span.close if span.respond_to?(:close)
+    def end_span(span, timestamp = Time.now)
+      span.close(timestamp) if span.respond_to?(:close)
     end
 
     def flush!

--- a/lib/zipkin-tracer/zipkin_sender_base.rb
+++ b/lib/zipkin-tracer/zipkin_sender_base.rb
@@ -20,8 +20,8 @@ module Trace
       result
     end
 
-    def end_span(span)
-      span.close
+    def end_span(span, timestamp = Time.now)
+      span.close(timestamp)
       # If in a thread not handling incoming http requests, it will not have Kind::SERVER, so the span
       # will never be flushed and will cause memory leak.
       # If no parent span, then current span needs to flush when it ends.
@@ -31,8 +31,8 @@ module Trace
       end
     end
 
-    def start_span(trace_id, name)
-      span = Span.new(name, trace_id)
+    def start_span(trace_id, name, timestamp = Time.now)
+      span = Span.new(name, trace_id, timestamp)
       span.local_endpoint = Trace.default_endpoint
       store_span(trace_id, span)
       span

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -59,6 +59,12 @@ describe Trace::ZipkinSenderBase do
       expect(tracer).to receive(:store_span).with(trace_id, anything)
       span
     end
+    it 'allows you pass an explicit timestamp' do
+      timestamp = Time.utc(2016, 1, 16, 23, 45, 2)
+      microseconds = 1452987902000000
+      span = tracer.start_span(trace_id, rpc_name, timestamp)
+      expect(microseconds).to eq(span.to_h[:timestamp])
+    end
   end
 
   describe '#end_span' do
@@ -81,6 +87,13 @@ describe Trace::ZipkinSenderBase do
       expect(tracer).to receive(:flush!)
       expect(tracer).to receive(:reset)
       tracer.end_span(span)
+    end
+    it 'allows you pass an explicit timestamp' do
+      span #touch it so it happens before we freeze time again
+      timestamp = Time.utc(2016, 1, 16, 23, 45, 2)
+      expect(tracer).to receive(:flush!)
+      tracer.end_span(span, timestamp)
+      expect(span.to_h[:duration]).to eq(2_000_000)
     end
   end
 


### PR DESCRIPTION
The [open tracing spec](https://github.com/opentracing/specification/blob/master/specification.md) allows for the clients to pass an optional start and end timestamp to spans. This change enables that option for clients while providing the default of the current wall time as defined in the spec.