### PR TITLE
Duplicate rack environment strings before calling recognize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.39.1
+* Duplicate rack environment strings so that applications that depend on this call only happening once don't break
+
 # 0.39.0
 * Allow clients to provide an explicit timestamp when starting and stopping spans
 

--- a/lib/zipkin-tracer/application.rb
+++ b/lib/zipkin-tracer/application.rb
@@ -12,13 +12,16 @@ module ZipkinTracer
       false
     end
 
+    def self.stub_env(env)
+      {
+        "PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO].dup,
+        "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD].dup
+      }
+    end
+
     def self.route(env)
       return nil unless defined?(Rails)
-      stub_env = {
-        "PATH_INFO" => env[ZipkinTracer::RackHandler::PATH_INFO],
-        "REQUEST_METHOD" => env[ZipkinTracer::RackHandler::REQUEST_METHOD]
-      }
-      req = Rack::Request.new(stub_env)
+      req = Rack::Request.new(stub_env(env))
       # Returns a string like /some/path/:id
       Rails.application.routes.router.recognize(req) do |route|
         return route.path.spec.to_s

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.39.0'.freeze
+  VERSION = '0.39.1'.freeze
 end

--- a/spec/lib/application_spec.rb
+++ b/spec/lib/application_spec.rb
@@ -113,4 +113,17 @@ module ZipkinTracer
       end
     end
   end
+
+  describe '.stub_env' do
+    context 'using a gem that modifies the path in place' do
+      let(:env) { { "PATH_INFO" => "path", "REQUEST_METHOD" => "METHOD" } }
+
+      it 'dups the strings so the rack environment is not accidentally modified in place' do
+        ZipkinTracer::Application.stub_env(env).each do |key, value|
+          expect(value).to eq(env[key])
+          expect(value.object_id).not_to eq(env[key].object_id)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Certain gems like [routing-filter](https://github.com/svenfuchs/routing-filter) modify the rack environment in place when recognizing a route. Applications that use this type of behavior depend on recognize only being called once. Third parties that use this call break these types of applications if they call recognize without duping the rack variables.


I couldn't really think of a better way to test this without the custom matcher but I'm all ears if someone has a better way to do it!