### PR TITLE
Make Faraday 0.13 the minimum version of that dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ dist: trusty
 jdk:
   - oraclejdk8
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
-  - 2.4.5
+  - 2.4.6
   - 2.3.8
   - jruby-9.1.17.0
-  - jruby-9.2.6.0
+  - jruby-9.2.8.0
 deploy:
   provider: rubygems
   api_key:
@@ -17,7 +17,7 @@ deploy:
   on:
     tags: true
     repo: openzipkin/zipkin-ruby
-    condition: "$TRAVIS_RUBY_VERSION == 2.6.2"
+    condition: "$TRAVIS_RUBY_VERSION == 2.6.3"
 notifications:
   webhooks:
     urls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
+# 0.39.2
+* Make Faraday 0.13 the minimum requirement.
+
 # 0.39.1
-* Duplicate rack environment strings so that applications that depend on this call only happening once don't break
+* Duplicate rack environment strings so that applications that depend on this call only happening once don't break.
 
 # 0.39.0
-* Allow clients to provide an explicit timestamp when starting and stopping spans
+* Allow clients to provide an explicit timestamp when starting and stopping spans.
 
 # 0.38.0
-* Add RabbitMQ sender
+* Add RabbitMQ sender.
 
 # 0.37.0
 * Add an `async` option to the HTTP and SQS senders.

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.39.1'.freeze
+  VERSION = '0.39.2'.freeze
 end

--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   end
   s.require_paths = ['lib']
 
-  s.add_dependency 'faraday', '~> 0.8'
+  s.add_dependency 'faraday', '~> 0.13'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 


### PR DESCRIPTION
Faraday 0.9 rename the namespace of the error classes. 
We are using the new namespace so using this gem with Faraday 0.8 will break when an exception from Faraday raises.

As I was updating it, I've made 0.13 the minimum. 0.13 was released 2 years ago so I think it should be safe enough.
@ykitamura-mdsol @jfeltesse-mdsol 