### PR TITLE
protect against double inserting middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.39.3
+* Protect Faraday and Excon middlewares against adding them twice.
+
 # 0.39.2
 * Make Faraday 0.13 the minimum requirement.
 

--- a/lib/zipkin-tracer/excon/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/excon/zipkin-tracer.rb
@@ -12,6 +12,8 @@ module ZipkinTracer
     end
 
     def request_call(datum)
+      return super(datum) if !datum[:headers][b3_headers().values.first].nil?
+
       trace_id = TraceGenerator.new.next_trace_id
 
       TraceContainer.with_trace_id(trace_id) do

--- a/lib/zipkin-tracer/faraday/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/faraday/zipkin-tracer.rb
@@ -10,6 +10,8 @@ module ZipkinTracer
     end
 
     def call(env)
+      # Prevent calling this middleware twice
+      return @app.call(env) if !env[:request_headers][b3_headers().values.first].nil?
       trace_id = TraceGenerator.new.next_trace_id
       TraceContainer.with_trace_id(trace_id) do
         b3_headers.each do |method, header|

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.39.2'.freeze
+  VERSION = '0.39.3'.freeze
 end

--- a/spec/lib/excon/zipkin-tracer_spec.rb
+++ b/spec/lib/excon/zipkin-tracer_spec.rb
@@ -15,6 +15,7 @@ describe ZipkinTracer::ExconHandler do
                           )
     connection.request
 
+    return headers if !headers.empty?
     request_headers = nil
     expect(a_request(:post, url).with { |req|
       # Webmock 'normalizes' the headers. E.g: X-B3-TraceId becomes X-B3-Traceid.

--- a/spec/lib/faraday/zipkin-tracer_spec.rb
+++ b/spec/lib/faraday/zipkin-tracer_spec.rb
@@ -27,7 +27,7 @@ describe ZipkinTracer::FaradayHandler do
       method: :post,
       url: url,
       body: body,
-      request_headers: {}, #Faraday::Utils::Headers.new(headers),
+      request_headers: headers, #Faraday::Utils::Headers.new(headers),
     }
     middleware.call(env).env[:request_headers]
   end

--- a/spec/lib/middleware_shared_examples.rb
+++ b/spec/lib/middleware_shared_examples.rb
@@ -91,6 +91,14 @@ shared_examples 'make requests' do |expect_to_trace_request|
       end
     end
 
+    it 'expects tracing once even when called twice' do
+      if expect_to_trace_request
+        expect_tracing
+        request_headers = process('', url)
+        process('', url, request_headers)
+      end
+    end
+
     it 'sets the X-B3 request headers with a new spanID' do
       request_headers  = nil
       ZipkinTracer::TraceContainer.with_trace_id(trace_id) do


### PR DESCRIPTION
It seems that mistake do happen and does not look nice. 
Thoughts on the approach? I could not find a way to find out at initialization time.

@ykitamura-mdsol  @jfeltesse-mdsol 