### PR TITLE
Reuse existing tracer(sender) in the TraceWrapper utility class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.42.0
+* Reuse existing tracer(sender) in the TraceWrapper utility class.
+
 # 0.41.0
 * Add support for writing B3 single header.
 * Omit ParentSpanId header for root spans.

--- a/lib/zipkin-tracer/trace_wrapper.rb
+++ b/lib/zipkin-tracer/trace_wrapper.rb
@@ -3,13 +3,12 @@ module ZipkinTracer
     def self.wrap_in_custom_span(config, span_name, span_kind: Trace::Span::Kind::SERVER, app: nil)
       raise ArgumentError, "you must provide a block" unless block_given?
 
-      zipkin_config = ZipkinTracer::Config.new(app, config).freeze
-      tracer = ZipkinTracer::TracerFactory.new.tracer(zipkin_config)
+      initialize_tracer(app, config)
       trace_id = ZipkinTracer::TraceGenerator.new.next_trace_id
 
       ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
         if trace_id.sampled?
-          tracer.with_new_span(trace_id, span_name) do |span|
+          Trace.tracer.with_new_span(trace_id, span_name) do |span|
             span.kind = span_kind
             yield(span)
           end
@@ -17,6 +16,13 @@ module ZipkinTracer
           yield(ZipkinTracer::NullSpan.new)
         end
       end
+    end
+
+    def self.initialize_tracer(app, config)
+      return if Trace.tracer
+
+      zipkin_config = ZipkinTracer::Config.new(app, config).freeze
+      ZipkinTracer::TracerFactory.new.tracer(zipkin_config)
     end
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.41.0'.freeze
+  VERSION = '0.42.0'.freeze
 end


### PR DESCRIPTION
Tracer(sender) seems to be reusable:
https://github.com/openzipkin/zipkin-ruby/blob/master/lib/zipkin-tracer/tracer_factory.rb

@adriancole @jcarres-mdsol @jfeltesse-mdsol