### PR TITLE
Fix to not flush producer span if a server span is in the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.43.1
+* Fix to not flush `PRODUCER` span when a server span is in the stack.
+
 # 0.43.0
 * Add the `PRODUCER` and `CONSUMER` span kinds.
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,3 +1,3 @@
 module ZipkinTracer
-  VERSION = '0.43.0'.freeze
+  VERSION = '0.43.1'.freeze
 end

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -118,6 +118,20 @@ describe Trace::ZipkinSenderBase do
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
   end
 
+  describe '#end_span with another server span' do
+    before do
+      span = tracer.start_span(trace_id, rpc_name)
+      span.kind = Trace::Span::Kind::SERVER
+    end
+
+    let(:span) { tracer.start_span(trace_id, rpc_name) }
+
+    include_examples 'flushes span', Trace::Span::Kind::SERVER
+    include_examples 'flushes span', Trace::Span::Kind::CLIENT
+    include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
+    include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+  end
+
   describe '#with_new_span' do
     let(:result) { 'result' }
     it 'returns the value of the block' do


### PR DESCRIPTION
A producer span can be created within a server span and if we flush the producer span before the server span gets closed, the server span will lose its duration information.

@adriancole @jcarres-mdsol @jfeltesse-mdsol 