### PR TITLE
Add trace_context option to TraceWrapper to retrieve trace data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.45.0
+* Add a `trace_context` option to the TraceWrapper utility class to retrieve trace data.
+
 # 0.44.0
 * Allow Faraday 1.x.
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ TraceWrapper.wrap_in_custom_span(config, "custom span") do |span|
 end
 ```
 
+The `trace_context:` keyword argument can be used to retrieve trace data:
+```ruby
+trace_context = { trace_id: '234555b04cf7e099', span_id: '234555b04cf7e099' }
+
+TraceWrapper.wrap_in_custom_span(config, "custom span", trace_context: trace_context) do |span|
+  :
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,7 @@ The `trace_context:` keyword argument can be used to retrieve trace data:
 trace_context = {
   trace_id: '234555b04cf7e099',
   span_id: '234555b04cf7e099',
-  sampled: 'true',
-  flags: '0'
+  sampled: 'true'
 }
 
 TraceWrapper.wrap_in_custom_span(config, "custom span", trace_context: trace_context) do |span|

--- a/README.md
+++ b/README.md
@@ -244,7 +244,12 @@ end
 
 The `trace_context:` keyword argument can be used to retrieve trace data:
 ```ruby
-trace_context = { trace_id: '234555b04cf7e099', span_id: '234555b04cf7e099' }
+trace_context = {
+  trace_id: '234555b04cf7e099',
+  span_id: '234555b04cf7e099',
+  sampled: 'true',
+  flags: '0'
+}
 
 TraceWrapper.wrap_in_custom_span(config, "custom span", trace_context: trace_context) do |span|
   :

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -115,21 +115,21 @@ module Trace
     end
 
     def next_id
-      TraceId.new(@trace_id, @span_id, ZipkinTracer::TraceGenerator.new.generate_id, @sampled, @flags)
+      TraceId.new(trace_id, span_id, ZipkinTracer::TraceGenerator.new.generate_id, sampled, flags)
     end
 
     # the debug flag is used to ensure the trace passes ALL samplers
     def debug?
-      @flags & Flags::DEBUG == Flags::DEBUG
+      flags & Flags::DEBUG == Flags::DEBUG
     end
 
     def sampled?
-      debug? || ['1', 'true'].include?(@sampled)
+      debug? || %w[1 true].include?(sampled)
     end
 
     def to_s
-      "TraceId(trace_id = #{@trace_id.to_s}, parent_id = #{@parent_id.to_s}, span_id = #{@span_id.to_s}," \
-      " sampled = #{@sampled.to_s}, flags = #{@flags.to_s}, shared = #{@shared.to_s})"
+      "TraceId(trace_id = #{trace_id}, parent_id = #{parent_id}, span_id = #{span_id}," \
+      " sampled = #{sampled}, flags = #{flags}, shared = #{shared})"
     end
   end
 

--- a/lib/zipkin-tracer/trace_wrapper.rb
+++ b/lib/zipkin-tracer/trace_wrapper.rb
@@ -1,10 +1,13 @@
 module ZipkinTracer
   class TraceWrapper
-    def self.wrap_in_custom_span(config, span_name, span_kind: Trace::Span::Kind::SERVER, app: nil)
+    REQUIRED_KEYS = %i[trace_id span_id].freeze
+    KEYS = %i[trace_id parent_id span_id sampled flags].freeze
+
+    def self.wrap_in_custom_span(config, span_name, span_kind: Trace::Span::Kind::SERVER, app: nil, trace_context: nil)
       raise ArgumentError, "you must provide a block" unless block_given?
 
       initialize_tracer(app, config)
-      trace_id = ZipkinTracer::TraceGenerator.new.next_trace_id
+      trace_id = next_trace_id(trace_context)
 
       ZipkinTracer::TraceContainer.with_trace_id(trace_id) do
         if trace_id.sampled?
@@ -23,6 +26,15 @@ module ZipkinTracer
 
       zipkin_config = ZipkinTracer::Config.new(app, config).freeze
       ZipkinTracer::TracerFactory.new.tracer(zipkin_config)
+    end
+
+    def self.next_trace_id(trace_context)
+      if trace_context.is_a?(Hash) && REQUIRED_KEYS.all? { |key| trace_context.key?(key) }
+        trace_context[:flags] = (trace_context[:flags] || Trace::Flags::EMPTY).to_i
+        Trace::TraceId.new(*trace_context.values_at(*KEYS)).next_id
+      else
+        ZipkinTracer::TraceGenerator.new.next_trace_id
+      end
     end
   end
 end

--- a/lib/zipkin-tracer/trace_wrapper.rb
+++ b/lib/zipkin-tracer/trace_wrapper.rb
@@ -1,7 +1,7 @@
 module ZipkinTracer
   class TraceWrapper
     REQUIRED_KEYS = %i[trace_id span_id].freeze
-    KEYS = %i[trace_id parent_id span_id sampled flags].freeze
+    KEYS = %i[trace_id parent_id span_id sampled].freeze
 
     def self.wrap_in_custom_span(config, span_name, span_kind: Trace::Span::Kind::SERVER, app: nil, trace_context: nil)
       raise ArgumentError, "you must provide a block" unless block_given?
@@ -30,8 +30,7 @@ module ZipkinTracer
 
     def self.next_trace_id(trace_context)
       if trace_context.is_a?(Hash) && REQUIRED_KEYS.all? { |key| trace_context.key?(key) }
-        trace_context[:flags] = (trace_context[:flags] || Trace::Flags::EMPTY).to_i
-        Trace::TraceId.new(*trace_context.values_at(*KEYS)).next_id
+        Trace::TraceId.new(*trace_context.values_at(*KEYS), Trace::Flags::EMPTY).next_id
       else
         ZipkinTracer::TraceGenerator.new.next_trace_id
       end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipkinTracer
-  VERSION = '0.44.0'
+  VERSION = '0.45.0'
 end

--- a/spec/lib/trace_wrapper_spec.rb
+++ b/spec/lib/trace_wrapper_spec.rb
@@ -95,7 +95,7 @@ describe ZipkinTracer::TraceWrapper do
     end
 
     context "trace_context option" do
-      let(:trace_context) { { trace_id: '234555b04cf7e099', span_id: '234555b04cf7e099', sampled: 'true', flags: '0' } }
+      let(:trace_context) { { trace_id: '234555b04cf7e099', span_id: '234555b04cf7e099', sampled: 'true' } }
 
       it "generates next trace_id from given trace_context hash" do
         expect(Trace::TraceId).to receive(:new).with('234555b04cf7e099', nil, '234555b04cf7e099', 'true', 0)

--- a/spec/lib/trace_wrapper_spec.rb
+++ b/spec/lib/trace_wrapper_spec.rb
@@ -93,5 +93,20 @@ describe ZipkinTracer::TraceWrapper do
         described_class.wrap_in_custom_span(config, "custom span") {}
       end
     end
+
+    context "trace_context option" do
+      let(:trace_context) { { trace_id: '234555b04cf7e099', span_id: '234555b04cf7e099', sampled: 'true', flags: '0' } }
+
+      it "generates next trace_id from given trace_context hash" do
+        expect(Trace::TraceId).to receive(:new).with('234555b04cf7e099', nil, '234555b04cf7e099', 'true', 0)
+          .and_return(double(next_id: double(sampled?: false)))
+        described_class.wrap_in_custom_span(config, "custom span", trace_context: trace_context) {}
+      end
+
+      it "generates next trace_id from ZipkinTracer::TraceGenerator when trace_context is not given" do
+        expect(ZipkinTracer::TraceGenerator).to receive(:new).and_call_original
+        described_class.wrap_in_custom_span(config, "custom span") {}
+      end
+    end
   end
 end


### PR DESCRIPTION
Added this option especially for the consumer side of messaging tracing to retrieve trace data easily.

The logic is a subset of the `ZipkinEnv` class:
https://github.com/openzipkin/zipkin-ruby/blob/0.44.0/lib/zipkin-tracer/rack/zipkin_env.rb#L39

@adriancole @jcarres-mdsol @jfeltesse-mdsol 

