### PR TITLE
Add Amazon SQS tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.46.0
+* Add Amazon SQS tracer.
+
 # 0.45.0
 * Add a `trace_context` option to the TraceWrapper utility class to retrieve trace data.
 

--- a/lib/zipkin-tracer/hostname_resolver.rb
+++ b/lib/zipkin-tracer/hostname_resolver.rb
@@ -11,15 +11,17 @@ module ZipkinTracer
 
       each_endpoint(spans) do |endpoint|
         hostname = endpoint.ipv4
-        unless resolved_ip_address?(hostname.to_s)
-          endpoint.ipv4 = resolved_hosts[hostname]
-        end
+        next unless hostname
+        next if resolved_ip_address?(hostname.to_s)
+
+        endpoint.ipv4 = resolved_hosts[hostname]
       end
     end
 
     private
+
     LOCALHOST = '127.0.0.1'.freeze
-    LOCALHOST_I32 = 0x7f000001.freeze
+    LOCALHOST_I32 = 0x7f000001
     MAX_I32 = ((2 ** 31) - 1)
     MASK = (2 ** 32) - 1
     IP_FIELD = 3
@@ -49,10 +51,9 @@ module ZipkinTracer
     end
 
     def resolve(hosts, ip_format)
-      hosts.inject({}) do |host_map, host|
+      hosts.each_with_object({}) do |host, host_map|
         hostname = host.ipv4  # This field has been temporarly used to store the hostname.
-        host_map[hostname]  = host_to_format(hostname, ip_format)
-        host_map
+        host_map[hostname] = host_to_format(hostname, ip_format) if hostname
       end
     end
 

--- a/lib/zipkin-tracer/sqs/adapter.rb
+++ b/lib/zipkin-tracer/sqs/adapter.rb
@@ -1,0 +1,4 @@
+require 'aws-sdk-sqs'
+require 'zipkin-tracer/sqs/zipkin-tracer'
+
+Aws::SQS::Client.prepend(ZipkinTracer::SqsHandler)

--- a/lib/zipkin-tracer/sqs/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/sqs/zipkin-tracer.rb
@@ -1,0 +1,57 @@
+module ZipkinTracer
+  # This module is designed to prepend to the SQS client to add trace data as message attributes.
+  # https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-sqs/lib/aws-sdk-sqs/client.rb
+  module SqsHandler
+    def send_message(params = {}, options = {})
+      zipkin_sqs_trace_wrapper(params, __method__) { |params_with_trace| super(params_with_trace, options) }
+    end
+
+    def send_message_batch(params = {}, options = {})
+      zipkin_sqs_trace_wrapper(params, __method__) { |params_with_trace| super(params_with_trace, options) }
+    end
+
+    private
+
+    ZIPKIN_KEYS = %i[trace_id parent_id span_id sampled].freeze
+    ZIPKIN_REMOTE_ENDPOINT_SQS = Trace::Endpoint.remote_endpoint(nil, 'amazon-sqs')
+
+    def zipkin_sqs_trace_wrapper(params, method_name)
+      trace_id = TraceGenerator.new.next_trace_id
+      zipkin_set_message_attributes(params, method_name, trace_id)
+
+      TraceContainer.with_trace_id(trace_id) do
+        if Trace.tracer && trace_id.sampled?
+          Trace.tracer.with_new_span(trace_id, method_name) do |span|
+            span.kind = Trace::Span::Kind::PRODUCER
+            span.remote_endpoint = ZIPKIN_REMOTE_ENDPOINT_SQS
+            span.record_tag('queue.url', params[:queue_url])
+            yield(params)
+          end
+        else
+          yield(params)
+        end
+      end
+    end
+
+    def zipkin_set_message_attributes(params, method_name, trace_id)
+      attributes = zipkin_message_attributes(trace_id)
+      case method_name
+      when :send_message
+        params[:message_attributes] = attributes.merge(params[:message_attributes] || {})
+      when :send_message_batch
+        params[:entries].each do |entry|
+          entry[:message_attributes] = attributes.merge(entry[:message_attributes] || {})
+        end
+      end
+    end
+
+    def zipkin_message_attributes(trace_id)
+      ZIPKIN_KEYS.each_with_object({}) do |zipkin_key, message_attributes|
+        zipkin_value = trace_id.send(zipkin_key)
+        next unless zipkin_value
+
+        message_attributes[zipkin_key] = { string_value: zipkin_value.to_s, data_type: 'String' }
+      end
+    end
+  end
+end

--- a/lib/zipkin-tracer/trace.rb
+++ b/lib/zipkin-tracer/trace.rb
@@ -277,8 +277,8 @@ module Trace
     end
 
     def self.remote_endpoint(url, remote_service_name)
-      service_name = remote_service_name || url.host.split('.').first || UNKNOWN_URL # default to url-derived service name
-      Endpoint.new(url.host, url.port, service_name)
+      service_name = remote_service_name || url&.host&.split('.')&.first || UNKNOWN_URL # default to url-derived service name
+      Endpoint.new(url&.host, url&.port, service_name)
     end
 
     def to_h

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipkinTracer
-  VERSION = '0.45.0'
+  VERSION = '0.46.0'
 end

--- a/lib/zipkin-tracer/zipkin_sender_base.rb
+++ b/lib/zipkin-tracer/zipkin_sender_base.rb
@@ -7,8 +7,7 @@ module Trace
   # Senders dealing with zipkin should inherit from this class and implement the
   # flush! method which actually sends the information
   class ZipkinSenderBase
-
-    def initialize(options={})
+    def initialize(options = {})
       @options = options
       reset
     end
@@ -40,7 +39,10 @@ module Trace
 
     def skip_flush?(span)
       return true if span.kind == Trace::Span::Kind::CLIENT && span.has_parent_span?
-      return true if span.kind == Trace::Span::Kind::PRODUCER && spans.any? { |s| s.kind == Trace::Span::Kind::SERVER }
+
+      if span.kind == Trace::Span::Kind::PRODUCER
+        return true if spans.any? { |s| s.kind == Trace::Span::Kind::SERVER || s.kind == Trace::Span::Kind::CONSUMER }
+      end
     end
 
     def flush!
@@ -62,6 +64,5 @@ module Trace
     def reset
       Thread.current[THREAD_KEY] = []
     end
-
   end
 end

--- a/spec/lib/sqs/adapter_spec.rb
+++ b/spec/lib/sqs/adapter_spec.rb
@@ -1,0 +1,46 @@
+require 'zipkin-tracer/sqs/adapter'
+
+describe 'SQS Adapter' do
+  let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, 'true', Trace::Flags::EMPTY) }
+  let(:queue_url) { 'http://sqs.com' }
+
+  before do
+    allow(Trace).to receive(:tracer).and_return(nil)
+    allow_any_instance_of(ZipkinTracer::TraceGenerator).to receive(:next_trace_id).and_return(trace_id)
+    Aws.config[:sqs] = {
+      stub_responses: {
+        get_queue_url: {
+          queue_url: queue_url
+        }
+      }
+    }
+  end
+
+  shared_examples_for 'method is overridden' do |method_name|
+    it 'generates a new trace_id' do
+      expect_any_instance_of(ZipkinTracer::TraceGenerator).to receive(:next_trace_id)
+      Aws::SQS::Client.new.send(method_name, params)
+    end
+  end
+
+  describe '#send_message' do
+    include_examples 'method is overridden', :send_message do
+      let(:params) { { queue_url: queue_url, message_body: 'test' } }
+    end
+  end
+
+  describe '#send_message_batch' do
+    include_examples 'method is overridden', :send_message_batch do
+      let(:params) do
+        {
+          queue_url: queue_url,
+          entries: [
+            { id: 'msg1', message_body: 'test' },
+            { id: 'msg2', message_body: 'hello world' }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/sqs/zipkin-tracer_spec.rb
+++ b/spec/lib/sqs/zipkin-tracer_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'zipkin-tracer/sqs/zipkin-tracer'
+require 'zipkin-tracer/zipkin_null_sender'
+
+describe ZipkinTracer::SqsHandler do
+  class FakeSqsClient
+    def send_message(params = {}, options = {})
+      [params, options]
+    end
+
+    def send_message_batch(params = {}, options = {})
+      [params, options]
+    end
+  end
+
+  FakeSqsClient.prepend(ZipkinTracer::SqsHandler)
+
+  let(:tracer) { Trace::NullSender.new }
+  let(:span_id) { ZipkinTracer::TraceGenerator.new.generate_id }
+  let(:trace_id) { Trace::TraceId.new(span_id, nil, span_id, sampled, Trace::Flags::EMPTY) }
+  let(:remote_endpoint) { Trace::Endpoint.remote_endpoint(nil, 'amazon-sqs') }
+  let(:queue_url) { 'http://sqs.com' }
+  let(:message_attributes) do
+    {
+      trace_id: {
+        data_type: 'String',
+        string_value: trace_id.trace_id.to_s
+      },
+      span_id: {
+        data_type: 'String',
+        string_value: trace_id.span_id.to_s
+      },
+      sampled: {
+        data_type: 'String',
+        string_value: sampled
+      }
+    }
+  end
+
+  before do
+    allow(Trace).to receive(:tracer).and_return(tracer)
+    allow_any_instance_of(ZipkinTracer::TraceGenerator).to receive(:next_trace_id).and_return(trace_id)
+  end
+
+  shared_examples_for 'add trace data' do |method_name|
+    context 'sampled' do
+      let(:sampled) { 'true' }
+
+      it 'generates a new span and adds trace data to the sqs message' do
+        expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).ordered.once.and_call_original
+        expect(tracer).to receive(:with_new_span).ordered.with(trace_id, method_name).and_call_original
+        expect_any_instance_of(Trace::Span).to receive(:kind=).with(Trace::Span::Kind::PRODUCER)
+        expect_any_instance_of(Trace::Span).to receive(:remote_endpoint=).with(remote_endpoint)
+        expect_any_instance_of(Trace::Span).to receive(:record_tag).with('queue.url', queue_url)
+        expect(FakeSqsClient.new.send(method_name, params)).to eq([expected_params, {}])
+      end
+    end
+
+    context 'not sampled' do
+      let(:sampled) { 'false' }
+
+      it 'does not generate a new span but adds trace data to the sqs message' do
+        expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).ordered.once.and_call_original
+        expect(tracer).not_to receive(:with_new_span)
+        expect_any_instance_of(Trace::Span).not_to receive(:kind=)
+        expect(FakeSqsClient.new.send(method_name, params)).to eq([expected_params, {}])
+      end
+    end
+  end
+
+  describe '#send_message' do
+    include_examples 'add trace data', :send_message do
+      let(:params) { { queue_url: queue_url, message_body: 'test' } }
+      let(:expected_params) { { queue_url: queue_url, message_body: 'test', message_attributes: message_attributes } }
+    end
+  end
+
+  describe '#send_message_batch' do
+    include_examples 'add trace data', :send_message_batch do
+      let(:params) do
+        {
+          queue_url: queue_url,
+          entries: [
+            { id: 'msg1', message_body: 'test' },
+            { id: 'msg2', message_body: 'hello world' }
+          ]
+        }
+      end
+      let(:expected_params) do
+        {
+          queue_url: queue_url,
+          entries: [
+            { id: 'msg1', message_body: 'test', message_attributes: message_attributes },
+            { id: 'msg2', message_body: 'hello world', message_attributes: message_attributes }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -132,6 +132,20 @@ describe Trace::ZipkinSenderBase do
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
   end
 
+  describe '#end_span with another consumer span' do
+    before do
+      span = tracer.start_span(trace_id, rpc_name)
+      span.kind = Trace::Span::Kind::CONSUMER
+    end
+
+    let(:span) { tracer.start_span(trace_id, rpc_name) }
+
+    include_examples 'flushes span', Trace::Span::Kind::SERVER
+    include_examples 'flushes span', Trace::Span::Kind::CLIENT
+    include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
+    include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+  end
+
   describe '#with_new_span' do
     let(:result) { 'result' }
     it 'returns the value of the block' do


### PR DESCRIPTION
Added SQS tracer to trace SQS messages.
This tracer will aggressively add trace data to all SQS messages.

Closes #136 

@adriancole @jcarres-mdsol @jfeltesse-mdsol