### PR TITLE
Add a 'check_routes' option to make the routable request check optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.47.0
+* Add a `check_routes` option to make the routable request check optional.
+
 # 0.46.0
 * Add Amazon SQS tracer.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ use ZipkinTracer::RackHandler, config
 * `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
+* `:check_routes` - When set to true, only routable requests are sampled.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
 * `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP, RabbitMQ, and SQS senders.
 * `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use ZipkinTracer::RackHandler, config
 * `:service_name` **REQUIRED** - the name of the service being traced. There are two ways to configure this value. Either write the service name in the config file or set the "DOMAIN" environment variable (e.g. 'test-service.example.com' or 'test-service'). The environment variable takes precedence over the config file value.
 * `:sample_rate` (default: 0.1) - the ratio of requests to sample, from 0 to 1
 * `:sampled_as_boolean` - When set to true (default but deprecrated), it uses true/false for the `X-B3-Sampled` header. When set to false uses 1/0 which is preferred.
-* `:check_routes` - When set to true, only routable requests are sampled.
+* `:check_routes` - When set to `true`, only routable requests are sampled. Defaults to `false`.
 * `:trace_id_128bit` - When set to true, high 8-bytes will be prepended to trace_id. The upper 4-bytes are epoch seconds and the lower 4-bytes are random. This makes it convertible to Amazon X-Ray trace ID format v1. (See http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html)
 * `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP, RabbitMQ, and SQS senders.
 * `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.

--- a/lib/zipkin-tracer/config.rb
+++ b/lib/zipkin-tracer/config.rb
@@ -5,7 +5,7 @@ require 'zipkin-tracer/rack/zipkin-tracer'
 module ZipkinTracer
   # Configuration of this gem. It reads the configuration and provides default values
   class Config
-    attr_reader :service_name, :sample_rate, :sampled_as_boolean, :trace_id_128bit, :async, :logger,
+    attr_reader :service_name, :sample_rate, :sampled_as_boolean, :check_routes, :trace_id_128bit, :async, :logger,
       :json_api_host, :zookeeper, :kafka_producer, :kafka_topic, :sqs_queue_name, :sqs_region, :log_tracing,
       :annotate_plugin, :filter_plugin, :whitelist_plugin, :rabbit_mq_connection, :rabbit_mq_exchange,
       :rabbit_mq_routing_key, :write_b3_single_format
@@ -47,6 +47,8 @@ module ZipkinTracer
       if @sampled_as_boolean
         @logger && @logger.warn("Using a boolean in the Sampled header is deprecated. Consider setting sampled_as_boolean to false")
       end
+      # When set to true, only routable requests are sampled
+      @check_routes      = config[:check_routes].nil? ? DEFAULTS[:check_routes] : config[:check_routes]
 
       # When set to true, high 8-bytes will be prepended to trace_id.
       # The upper 4-bytes are epoch seconds and the lower 4-bytes are random.
@@ -95,6 +97,7 @@ module ZipkinTracer
     DEFAULTS = {
       sample_rate: 0.1,
       sampled_as_boolean: true,
+      check_routes: false,
       trace_id_128bit: false,
       write_b3_single_format: false
     }

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -71,7 +71,7 @@ module ZipkinTracer
       if parent_trace_sampled # A service upstream decided this goes in all the way
         parent_trace_sampled
       else
-        new_sampled_header_value(force_sample? || current_trace_sampled? && !filtered? && routable_request?)
+        new_sampled_header_value(force_sample? || current_trace_sampled? && !filtered? && traceable_request?)
       end
     end
 
@@ -83,9 +83,10 @@ module ZipkinTracer
       @config.filter_plugin && !@config.filter_plugin.call(@env)
     end
 
-    def routable_request?
+    def traceable_request?
+      return true unless @config.check_routes
+
       Application.routable_request?(@env)
     end
-
   end
 end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipkinTracer
-  VERSION = '0.46.0'
+  VERSION = '0.47.0'
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -22,7 +22,7 @@ module ZipkinTracer
 
     it 'sets defaults' do
       config = Config.new(nil, {})
-      [:sample_rate, :sampled_as_boolean, :trace_id_128bit].each do |key|
+      [:sample_rate, :sampled_as_boolean, :check_routes, :trace_id_128bit, :write_b3_single_format].each do |key|
         expect(config.send(key)).to_not eq(nil)
       end
     end


### PR DESCRIPTION
### Background

The Rails framework uses a hidden `_method` parameter to send "PATCH", "PUT", and "DELETE" requests over "POST":
https://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-patch-put-or-delete-methods-work-questionmark

If "POST" is excluded in the `config/routes.rb` file like this:
```ruby
resources :users, except: [:create] do
  :
```

"PATCH", "PUT", and "DELETE" requests are also not recognizable by this method:
`Rails.application.routes.recognize_path(path_info, method: http_method)`


add the `Application.routable_request?` method will return `false`:
https://github.com/openzipkin/zipkin-ruby/blob/938f9a3fe7c88e75ad8fd0ac6a08bf9d4a784773/lib/zipkin-tracer/application.rb#L4-L13

@adriancole @jcarres-mdsol @jfeltesse-mdsol 