### PR TITLE
Fix to set SERVER span kind at the beginning to avoid being flushed before closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.47.1
+* Fix to set `SERVER` span kind at the beginning to avoid being flushed before closing.
+
 # 0.47.0
 * Add a `check_routes` option to make the routable request check optional.
 

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -25,6 +25,7 @@ module ZipkinTracer
           @app.call(env)
         else
           @tracer.with_new_span(trace_id, span_name(env)) do |span|
+            span.kind = Trace::Span::Kind::SERVER
             trace!(span, zipkin_env) { @app.call(env) }
           end
         end
@@ -47,7 +48,6 @@ module ZipkinTracer
     end
 
     def trace!(span, zipkin_env, &block)
-      span.kind = Trace::Span::Kind::SERVER
       status, headers, body = yield
     ensure
       trace_server_information(span, zipkin_env, status)

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -47,6 +47,7 @@ module ZipkinTracer
     end
 
     def trace!(span, zipkin_env, &block)
+      span.kind = Trace::Span::Kind::SERVER
       status, headers, body = yield
     ensure
       trace_server_information(span, zipkin_env, status)
@@ -55,7 +56,6 @@ module ZipkinTracer
     end
 
     def trace_server_information(span, zipkin_env, status)
-      span.kind = Trace::Span::Kind::SERVER
       span.record_status(status)
       SERVER_RECV_TAGS.each { |annotation_key, env_key| span.record_tag(annotation_key, zipkin_env.env[env_key]) }
     end

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipkinTracer
-  VERSION = '0.47.0'
+  VERSION = '0.47.1'
 end

--- a/spec/lib/rack/zipkin-tracer_spec.rb
+++ b/spec/lib/rack/zipkin-tracer_spec.rb
@@ -215,4 +215,23 @@ describe ZipkinTracer::RackHandler do
 
     end
   end
+
+  context 'SERVER span kind' do
+    subject { middleware(app) }
+
+    let(:span) { double }
+
+    before do
+      allow(tracer).to receive(:start_span).and_return(span)
+    end
+
+    it 'sets SERVER span kind before calling trace!' do
+      expect(ZipkinTracer::TraceContainer).to receive(:with_trace_id).and_call_original
+      expect(tracer).to receive(:with_new_span).ordered.with(anything, 'get').and_call_original
+      expect(span).to receive(:kind=).ordered.with(Trace::Span::Kind::SERVER)
+      expect(subject).to receive(:trace!).ordered
+
+      status, headers, body = subject.call(mock_env)
+    end
+  end
 end


### PR DESCRIPTION
If a `SERVER` span has a `PRODUCER` child span, it will be flushed when the child span is closed if span kind is not yet set:

https://github.com/openzipkin/zipkin-ruby/blob/2c71f1dccd5df9a0dcbb0358b9d78b6ca0fa1270/lib/zipkin-tracer/zipkin_sender_base.rb#L43-L45

@adriancole @jcarres-mdsol 