### PR TITLE
Fix to not flush local component span when a server span or a consumer span is in the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.47.2
+* Fix to not flush local component span when a server span or a consumer span is in the stack.
+
 # 0.47.1
 * Fix to set `SERVER` span kind at the beginning to avoid being flushed before closing.
 

--- a/lib/zipkin-tracer/version.rb
+++ b/lib/zipkin-tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipkinTracer
-  VERSION = '0.47.1'
+  VERSION = '0.47.2'
 end

--- a/lib/zipkin-tracer/zipkin_sender_base.rb
+++ b/lib/zipkin-tracer/zipkin_sender_base.rb
@@ -40,7 +40,7 @@ module Trace
     def skip_flush?(span)
       return true if span.kind == Trace::Span::Kind::CLIENT && span.has_parent_span?
 
-      if span.kind == Trace::Span::Kind::PRODUCER
+      if span.kind.nil? || span.kind == Trace::Span::Kind::PRODUCER
         return true if spans.any? { |s| s.kind == Trace::Span::Kind::SERVER || s.kind == Trace::Span::Kind::CONSUMER }
       end
     end

--- a/lib/zipkin-tracer/zipkin_sender_base.rb
+++ b/lib/zipkin-tracer/zipkin_sender_base.rb
@@ -38,11 +38,9 @@ module Trace
     end
 
     def skip_flush?(span)
-      return true if span.kind == Trace::Span::Kind::CLIENT && span.has_parent_span?
+      return false if span.kind == Trace::Span::Kind::SERVER || span.kind == Trace::Span::Kind::CONSUMER
 
-      if span.kind.nil? || span.kind == Trace::Span::Kind::PRODUCER
-        return true if spans.any? { |s| s.kind == Trace::Span::Kind::SERVER || s.kind == Trace::Span::Kind::CONSUMER }
-      end
+      spans.any? { |s| s.kind == Trace::Span::Kind::SERVER || s.kind == Trace::Span::Kind::CONSUMER }
     end
 
     def flush!

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -99,6 +99,7 @@ describe Trace::ZipkinSenderBase do
     include_examples 'flushes span', Trace::Span::Kind::CLIENT
     include_examples 'flushes span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+    include_examples 'flushes span', nil
 
     it 'allows you pass an explicit timestamp' do
       span #touch it so it happens before we freeze time again
@@ -116,6 +117,7 @@ describe Trace::ZipkinSenderBase do
     include_examples 'does not flush span', Trace::Span::Kind::CLIENT
     include_examples 'flushes span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+    include_examples 'flushes span', nil
   end
 
   describe '#end_span with another server span' do
@@ -130,6 +132,7 @@ describe Trace::ZipkinSenderBase do
     include_examples 'flushes span', Trace::Span::Kind::CLIENT
     include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+    include_examples 'does not flush span', nil
   end
 
   describe '#end_span with another consumer span' do
@@ -144,6 +147,7 @@ describe Trace::ZipkinSenderBase do
     include_examples 'flushes span', Trace::Span::Kind::CLIENT
     include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
+    include_examples 'does not flush span', nil
   end
 
   describe '#with_new_span' do

--- a/spec/lib/zipkin_sender_base_spec.rb
+++ b/spec/lib/zipkin_sender_base_spec.rb
@@ -110,16 +110,6 @@ describe Trace::ZipkinSenderBase do
     end
   end
 
-  describe '#end_span with parent span' do
-    let(:span) { tracer.start_span(trace_id_with_parent, rpc_name) }
-
-    include_examples 'flushes span', Trace::Span::Kind::SERVER
-    include_examples 'does not flush span', Trace::Span::Kind::CLIENT
-    include_examples 'flushes span', Trace::Span::Kind::PRODUCER
-    include_examples 'flushes span', Trace::Span::Kind::CONSUMER
-    include_examples 'flushes span', nil
-  end
-
   describe '#end_span with another server span' do
     before do
       span = tracer.start_span(trace_id, rpc_name)
@@ -129,7 +119,7 @@ describe Trace::ZipkinSenderBase do
     let(:span) { tracer.start_span(trace_id, rpc_name) }
 
     include_examples 'flushes span', Trace::Span::Kind::SERVER
-    include_examples 'flushes span', Trace::Span::Kind::CLIENT
+    include_examples 'does not flush span', Trace::Span::Kind::CLIENT
     include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
     include_examples 'does not flush span', nil
@@ -144,7 +134,7 @@ describe Trace::ZipkinSenderBase do
     let(:span) { tracer.start_span(trace_id, rpc_name) }
 
     include_examples 'flushes span', Trace::Span::Kind::SERVER
-    include_examples 'flushes span', Trace::Span::Kind::CLIENT
+    include_examples 'does not flush span', Trace::Span::Kind::CLIENT
     include_examples 'does not flush span', Trace::Span::Kind::PRODUCER
     include_examples 'flushes span', Trace::Span::Kind::CONSUMER
     include_examples 'does not flush span', nil


### PR DESCRIPTION
follow up on #178

No span kind is specified for local component spans: 
https://github.com/openzipkin/zipkin-ruby/blob/50640d9c852c77c33670cedf61031b04b46ea984/lib/zipkin-tracer/trace_client.rb#L20-L23

Updated to not flush local component span (span.kind = `nil`) when SERVER or CONSUMER span is in the stack.

@adriancole @jcarres-mdsol