### PR TITLE
Add setting to disable shared spans (joins) in tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ use ZipkinTracer::RackHandler, config
 * `:async` - By default senders will flush traces asynchronously. Set to `false` to make that process synchronous. Only supported by the HTTP, RabbitMQ, and SQS senders.
 * `:logger` - The default logger for Rails apps is `Rails.logger`, else it is `STDOUT`. Use this option to pass a custom logger.
 * `:write_b3_single_format` - When set to true, only writes a single b3 header for outbound propagation.
+* `:supports_join` - When set to false, it will force client and server spans to have different spanId's. This may be needed because zipkin traces may be reported to non-zipkin backends that might not support the concept of joining spans.
 
 #### Sender specific
 * `:json_api_host` - Hostname with protocol of a zipkin api instance (e.g. `https://zipkin.example.com`) to use the HTTP sender

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -30,6 +30,10 @@ module ZipkinTracer
     B3_REQUIRED_HEADERS = %w[HTTP_X_B3_TRACEID HTTP_X_B3_SPANID].freeze
     B3_OPT_HEADERS = %w[HTTP_X_B3_PARENTSPANID HTTP_X_B3_SAMPLED HTTP_X_B3_FLAGS].freeze
 
+    def supports_join?
+      @config.supports_join
+    end
+
     def retrieve_or_generate_ids
       if called_with_zipkin_b3_single_header?
         trace_id, span_id, parent_span_id, sampled, flags =
@@ -38,6 +42,11 @@ module ZipkinTracer
       elsif called_with_zipkin_headers?
         trace_id, span_id, parent_span_id, sampled, flags = @env.values_at(*B3_REQUIRED_HEADERS, *B3_OPT_HEADERS)
         shared = true
+      end
+
+      unless supports_join?
+        span_id = TraceGenerator.new.generate_id
+        shared = false
       end
 
       unless trace_id

--- a/lib/zipkin-tracer/rack/zipkin_env.rb
+++ b/lib/zipkin-tracer/rack/zipkin_env.rb
@@ -45,6 +45,7 @@ module ZipkinTracer
       end
 
       unless supports_join?
+        parent_span_id = span_id
         span_id = TraceGenerator.new.generate_id
         shared = false
       end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -8,7 +8,7 @@ module ZipkinTracer
 
     [:service_name, :json_api_host,
       :zookeeper, :log_tracing,
-      :annotate_plugin, :filter_plugin, :whitelist_plugin].each do |method|
+      :annotate_plugin, :filter_plugin, :whitelist_plugin, :supports_join].each do |method|
       it "can set and read configuration values for #{method}" do
         value = rand(100)
         config = Config.new(nil, { method => value })
@@ -22,7 +22,7 @@ module ZipkinTracer
 
     it 'sets defaults' do
       config = Config.new(nil, {})
-      [:sample_rate, :sampled_as_boolean, :check_routes, :trace_id_128bit, :write_b3_single_format].each do |key|
+      [:sample_rate, :sampled_as_boolean, :check_routes, :trace_id_128bit, :write_b3_single_format, :supports_join].each do |key|
         expect(config.send(key)).to_not eq(nil)
       end
     end

--- a/spec/lib/rack/zipkin_env_spec.rb
+++ b/spec/lib/rack/zipkin_env_spec.rb
@@ -198,6 +198,7 @@ describe ZipkinTracer::ZipkinEnv do
           trace_id = zipkin_env.trace_id
           expect(trace_id.trace_id.to_i).to eq(id)
           expect(trace_id.span_id.to_i).not_to eq(id)
+          expect(trace_id.parent_id.to_i).to eq(id)
         end
 
         it 'shared is false' do

--- a/spec/lib/rack/zipkin_env_spec.rb
+++ b/spec/lib/rack/zipkin_env_spec.rb
@@ -19,11 +19,13 @@ describe ZipkinTracer::ZipkinEnv do
       whitelist_plugin: whitelist_plugin,
       sample_rate: sample_rate,
       sampled_as_boolean: sampled_as_boolean,
-      check_routes: check_routes
+      check_routes: check_routes,
+      supports_join: supports_join
     )
   end
   let(:env) { mock_env }
   let(:zipkin_env) { described_class.new(env, config) }
+  let(:supports_join) { true }
 
   it 'allows access to the original environment' do
     expect(zipkin_env.env).to eq(env)
@@ -187,6 +189,20 @@ describe ZipkinTracer::ZipkinEnv do
 
       it 'uses the flags' do
         expect(zipkin_env.trace_id.flags.to_i).to eq(0)
+      end
+
+      context 'supports joins is false' do
+        let(:supports_join) { false }
+
+        it 'generates a new span id' do
+          trace_id = zipkin_env.trace_id
+          expect(trace_id.trace_id.to_i).to eq(id)
+          expect(trace_id.span_id.to_i).not_to eq(id)
+        end
+
+        it 'shared is false' do
+          expect(zipkin_env.trace_id.shared).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
Addresses #125 by adding setting to disable support for joins.

When set to false, the it will force client and server spans to have different spanId's. This may be needed because zipkin traces may be reported to non-zipkin backends that might not support the concept of joining spans.